### PR TITLE
Dev eni

### DIFF
--- a/modules/aws/eni/main.tf
+++ b/modules/aws/eni/main.tf
@@ -10,10 +10,9 @@ resource "aws_network_interface" "eni" {
   source_dest_check = var.source_dest_check
   subnet_id         = var.subnet_id
   tags              = var.tags
+  attachment {
+    instance     = var.instance_id
+    device_index = var.device_index
+  }
 }
 
-resource "aws_network_interface_attachment" "eni_attach" {
-  device_index         = var.device_index
-  instance_id          = var.instance_id
-  network_interface_id = aws_network_interface.eni.id
-}

--- a/modules/aws/eni/main.tf
+++ b/modules/aws/eni/main.tf
@@ -3,13 +3,13 @@ terraform {
 }
 
 resource "aws_network_interface" "eni" {
-  attachment        = var.attachment
   private_ips       = var.private_ips
   private_ips_count = var.private_ips_count
   security_groups   = var.security_groups
   source_dest_check = var.source_dest_check
   subnet_id         = var.subnet_id
   tags              = var.tags
+  
   attachment {
     instance     = var.instance_id
     device_index = var.device_index


### PR DESCRIPTION
- Updated ENI module. It does not appear to be used in any repositories base on a search. It was not functioning properly. 
- Removed ENI attachment resource and replaced with attachment block instead. 
- Verified successful run using the dev branch - https://github.com/thinkstack-co/ventura_prod_snypr/pull/4