### PR TITLE
Dev new s3

### DIFF
--- a/modules/aws/s3_legacy_no_encryption/README.md
+++ b/modules/aws/s3_legacy_no_encryption/README.md
@@ -1,0 +1,37 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| acl | (Optional) The canned ACL to apply. Defaults to private. | `string` | `"private"` | no |
+| bucket\_prefix | (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. | `any` | n/a | yes |
+| kms\_master\_key\_id | (optional) The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse\_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse\_algorithm is aws:kms. | `string` | `""` | no |
+| mfa\_delete | (Optional) Enable MFA delete for either Change the versioning state of your bucket or Permanently delete an object version. Default is false. | `bool` | `false` | no |
+| policy | (Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. | `string` | `""` | no |
+| region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | `any` | n/a | yes |
+| sse\_algorithm | (required) The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | `string` | `"aws:kms"` | no |
+| tags | (Optional) A mapping of tags to assign to the bucket. | `map` | <pre>{<br>  "created_by": "Zachary Hill",<br>  "environment": "prod",<br>  "terraform": "true"<br>}</pre> | no |
+| target\_bucket | (Required) The name of the bucket that will receive the log objects. | `string` | `""` | no |
+| target\_prefix | (Optional) To specify a key prefix for log objects. | `string` | `"log/"` | no |
+| versioning | (Optional) A state of versioning (documented below) | `bool` | `true` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| s3\_bucket\_arn | n/a |
+| s3\_bucket\_domain\_name | n/a |
+| s3\_bucket\_id | n/a |
+| s3\_bucket\_region | n/a |
+| s3\_hosted\_zone\_id | n/a |

--- a/modules/aws/s3_legacy_no_encryption/main.tf
+++ b/modules/aws/s3_legacy_no_encryption/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+resource "aws_s3_bucket" "s3_bucket" {
+  acl    = var.acl
+  bucket = var.bucket
+  policy = var.policy
+
+  /*logging {
+        target_bucket = var.target_bucket
+        target_prefix = var.target_prefix
+    }*/
+
+  versioning {
+    enabled    = var.versioning
+    mfa_delete = var.mfa_delete
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = var.tags
+}

--- a/modules/aws/s3_legacy_no_encryption/outputs.tf
+++ b/modules/aws/s3_legacy_no_encryption/outputs.tf
@@ -1,0 +1,27 @@
+output "s3_bucket_id" {
+  value = aws_s3_bucket.s3_bucket.id
+}
+
+output "s3_bucket_arn" {
+  value = aws_s3_bucket.s3_bucket.arn
+}
+
+output "s3_bucket_domain_name" {
+  value = aws_s3_bucket.s3_bucket.bucket_domain_name
+}
+
+output "s3_hosted_zone_id" {
+  value = aws_s3_bucket.s3_bucket.hosted_zone_id
+}
+
+output "s3_bucket_region" {
+  value = aws_s3_bucket.s3_bucket.region
+}
+
+/*output "s3_bucket_website_endpoint" {
+    value = aws_s3_bucket.s3_bucket.website_endpoint
+}
+
+output "s3_bucket_website_domain" {
+    value = aws_s3_bucket.s3_bucket.website_domain
+}*/

--- a/modules/aws/s3_legacy_no_encryption/variables.tf
+++ b/modules/aws/s3_legacy_no_encryption/variables.tf
@@ -1,0 +1,57 @@
+variable "acl" {
+  description = "(Optional) The canned ACL to apply. Defaults to private."
+  default     = "private"
+}
+
+variable "bucket" {
+  description = "(Required) The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule."
+}
+
+variable "kms_master_key_id" {
+  type        = string
+  description = "(optional) The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse_algorithm is aws:kms."
+  default     = ""
+}
+
+variable "policy" {
+  description = "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy."
+  default     = ""
+}
+
+variable "sse_algorithm" {
+  type        = string
+  description = "(required) The server-side encryption algorithm to use. Valid values are AES256 and aws:kms"
+  default     = "aws:kms"
+}
+
+variable "tags" {
+  type        = map
+  description = "(Optional) A mapping of tags to assign to the bucket."
+  default = {
+    created_by  = "Zachary Hill"
+    environment = "prod"
+    terraform   = "true"
+  }
+}
+
+variable "target_bucket" {
+  type        = string
+  description = "(Required) The name of the bucket that will receive the log objects."
+  default     = ""
+}
+
+variable "target_prefix" {
+  type        = string
+  description = "(Optional) To specify a key prefix for log objects."
+  default     = "log/"
+}
+
+variable "versioning" {
+  description = "(Optional) A state of versioning (documented below)"
+  default     = true
+}
+
+variable "mfa_delete" {
+  description = "(Optional) Enable MFA delete for either Change the versioning state of your bucket or Permanently delete an object version. Default is false."
+  default     = false
+}

--- a/modules/aws/s3_no_encryption/README.md
+++ b/modules/aws/s3_no_encryption/README.md
@@ -1,0 +1,37 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| acl | (Optional) The canned ACL to apply. Defaults to private. | `string` | `"private"` | no |
+| bucket\_prefix | (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. | `any` | n/a | yes |
+| kms\_master\_key\_id | (optional) The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse\_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse\_algorithm is aws:kms. | `string` | `""` | no |
+| mfa\_delete | (Optional) Enable MFA delete for either Change the versioning state of your bucket or Permanently delete an object version. Default is false. | `bool` | `false` | no |
+| policy | (Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. | `string` | `""` | no |
+| region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | `any` | n/a | yes |
+| sse\_algorithm | (required) The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | `string` | `"aws:kms"` | no |
+| tags | (Optional) A mapping of tags to assign to the bucket. | `map` | <pre>{<br>  "created_by": "Zachary Hill",<br>  "environment": "prod",<br>  "terraform": "true"<br>}</pre> | no |
+| target\_bucket | (Required) The name of the bucket that will receive the log objects. | `string` | `""` | no |
+| target\_prefix | (Optional) To specify a key prefix for log objects. | `string` | `"log/"` | no |
+| versioning | (Optional) A state of versioning (documented below) | `bool` | `true` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| s3\_bucket\_arn | n/a |
+| s3\_bucket\_domain\_name | n/a |
+| s3\_bucket\_id | n/a |
+| s3\_bucket\_region | n/a |
+| s3\_hosted\_zone\_id | n/a |

--- a/modules/aws/s3_no_encryption/main.tf
+++ b/modules/aws/s3_no_encryption/main.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+resource "aws_s3_bucket" "s3_bucket" {
+  acl           = var.acl
+  bucket_prefix = var.bucket_prefix
+  policy        = var.policy
+
+  /*logging {
+        target_bucket = var.target_bucket
+        target_prefix = var.target_prefix
+    }*/
+
+  versioning {
+    enabled    = var.versioning
+    mfa_delete = var.mfa_delete
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = var.tags
+}

--- a/modules/aws/s3_no_encryption/outputs.tf
+++ b/modules/aws/s3_no_encryption/outputs.tf
@@ -1,0 +1,27 @@
+output "s3_bucket_id" {
+  value = aws_s3_bucket.s3_bucket.id
+}
+
+output "s3_bucket_arn" {
+  value = aws_s3_bucket.s3_bucket.arn
+}
+
+output "s3_bucket_domain_name" {
+  value = aws_s3_bucket.s3_bucket.bucket_domain_name
+}
+
+output "s3_hosted_zone_id" {
+  value = aws_s3_bucket.s3_bucket.hosted_zone_id
+}
+
+output "s3_bucket_region" {
+  value = aws_s3_bucket.s3_bucket.region
+}
+
+/*output "s3_bucket_website_endpoint" {
+    value = aws_s3_bucket.s3_bucket.website_endpoint
+}
+
+output "s3_bucket_website_domain" {
+    value = aws_s3_bucket.s3_bucket.website_domain
+}*/

--- a/modules/aws/s3_no_encryption/variables.tf
+++ b/modules/aws/s3_no_encryption/variables.tf
@@ -1,0 +1,57 @@
+variable "acl" {
+  description = "(Optional) The canned ACL to apply. Defaults to private."
+  default     = "private"
+}
+
+variable "bucket_prefix" {
+  description = "(Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket."
+}
+
+variable "kms_master_key_id" {
+  type        = string
+  description = "(optional) The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse_algorithm is aws:kms."
+  default     = ""
+}
+
+variable "policy" {
+  description = "(Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy."
+  default     = ""
+}
+
+variable "sse_algorithm" {
+  type        = string
+  description = "(required) The server-side encryption algorithm to use. Valid values are AES256 and aws:kms"
+  default     = "aws:kms"
+}
+
+variable "tags" {
+  type        = map
+  description = "(Optional) A mapping of tags to assign to the bucket."
+  default = {
+    created_by  = "Zachary Hill"
+    environment = "prod"
+    terraform   = "true"
+  }
+}
+
+variable "target_bucket" {
+  type        = string
+  description = "(Required) The name of the bucket that will receive the log objects."
+  default     = ""
+}
+
+variable "target_prefix" {
+  type        = string
+  description = "(Optional) To specify a key prefix for log objects."
+  default     = "log/"
+}
+
+variable "versioning" {
+  description = "(Optional) A state of versioning (documented below)"
+  default     = true
+}
+
+variable "mfa_delete" {
+  description = "(Optional) Enable MFA delete for either Change the versioning state of your bucket or Permanently delete an object version. Default is false."
+  default     = false
+}


### PR DESCRIPTION
Need some S3 bucket modules that do not use encryption. It creates extra overhead providing users access to KMS keys when bucket contents is being used publicly anyway. I created 2 new modules - 1 for legacy buckets, 1 for new buckets. 

Pull request one was used in  - https://github.com/thinkstack-co/proponent_prod_website/pull/16
Run from this pull request - https://app.terraform.io/app/thinkstack-co/workspaces/proponent_prod_website/runs/run-U7qo5mthSYJpdcHp