### PR TITLE
Flow logs - Improvements and default enforcement

### DIFF
--- a/modules/aws/flow_logs/README.md
+++ b/modules/aws/flow_logs/README.md
@@ -21,7 +21,6 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
     key_usage
     key_is_enabled
     key_name
-    key_policy
     cloudwatch_name_prefix
     cloudwatch_retention_in_days
     iam_policy_description
@@ -47,7 +46,6 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
     key_usage
     key_is_enabled
     key_name
-    key_policy
     cloudwatch_name_prefix
     cloudwatch_retention_in_days
     iam_policy_description

--- a/modules/aws/flow_logs/README.md
+++ b/modules/aws/flow_logs/README.md
@@ -8,7 +8,8 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
 
     module "flow_logs" {
         source = "github.com/thinkstack-co/terraform-modules//modules/aws/flow_logs"
-        
+
+        aws_region = var.aws_region
     }
 
 # Variables

--- a/modules/aws/flow_logs/README.md
+++ b/modules/aws/flow_logs/README.md
@@ -1,7 +1,7 @@
 Flow Logs Module
 =================
 
-This module sets up each componenet required to capture ENI Flow Logs with the parameters specified. By default this module will be set up to work without any changes to variables.
+This module sets up each componenet required to capture ENI Flow Logs with the parameters specified. By default this module will be set up to work without any changes to variables. The result of this module creates a unique cloudwatch log group with a prefix of 'flow_logs', an IAM policy and IAM role which can be used with ENI flow logs to deliver logs to that cloudwatch log group.
 
 
 # Usage

--- a/modules/aws/flow_logs/README.md
+++ b/modules/aws/flow_logs/README.md
@@ -32,9 +32,10 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
     iam_role_max_session_duration
     iam_role_name
     iam_role_permissions_boundary
+    aws_region
     tags
 ## Required
-    None
+    aws_region
 
 ## Optional
     key_bypass_policy_lockout_safety_check

--- a/modules/aws/flow_logs/README.md
+++ b/modules/aws/flow_logs/README.md
@@ -1,0 +1,62 @@
+Flow Logs Module
+=================
+
+This module sets up each componenet required to capture ENI Flow Logs with the parameters specified. By default this module will be set up to work without any changes to variables.
+
+
+# Usage
+
+    module "flow_logs" {
+        source = "github.com/thinkstack-co/terraform-modules//modules/aws/flow_logs"
+        
+    }
+
+# Variables
+    key_bypass_policy_lockout_safety_check
+    key_customer_master_key_spec
+    key_description
+    key_deletion_window_in_days
+    key_enable_key_rotation
+    key_usage
+    key_is_enabled
+    key_name
+    key_policy
+    cloudwatch_name_prefix
+    cloudwatch_retention_in_days
+    iam_policy_description
+    iam_policy_name
+    iam_policy_path
+    iam_role_assume_role_policy
+    iam_role_description
+    iam_role_force_detach_policies
+    iam_role_max_session_duration
+    iam_role_name
+    iam_role_permissions_boundary
+    tags
+## Required
+    None
+
+## Optional
+    key_bypass_policy_lockout_safety_check
+    key_customer_master_key_spec
+    key_description
+    key_deletion_window_in_days
+    key_enable_key_rotation
+    key_usage
+    key_is_enabled
+    key_name
+    key_policy
+    cloudwatch_name_prefix
+    cloudwatch_retention_in_days
+    iam_policy_description
+    iam_policy_name
+    iam_policy_path
+    iam_role_assume_role_policy
+    iam_role_description
+    iam_role_force_detach_policies
+    iam_role_max_session_duration
+    iam_role_name
+    iam_role_permissions_boundary
+    tags
+# Outputs
+    arn

--- a/modules/aws/flow_logs/README.md
+++ b/modules/aws/flow_logs/README.md
@@ -13,7 +13,6 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
     }
 
 # Variables
-    key_bypass_policy_lockout_safety_check
     key_customer_master_key_spec
     key_description
     key_deletion_window_in_days
@@ -33,7 +32,6 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
     iam_role_name_prefix
     iam_role_permissions_boundary
     flow_log_destination_type
-    flow_log_format
     flow_max_aggregation_interval
     flow_traffic_type
     flow_vpc_id
@@ -62,7 +60,6 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
     iam_role_name_prefix
     iam_role_permissions_boundary
     flow_log_destination_type
-    flow_log_format
     flow_max_aggregation_interval
     flow_traffic_type
     tags

--- a/modules/aws/flow_logs/README.md
+++ b/modules/aws/flow_logs/README.md
@@ -18,17 +18,17 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
     key_enable_key_rotation
     key_usage
     key_is_enabled
-    key_name
+    key_name_prefix
     cloudwatch_name_prefix
     cloudwatch_retention_in_days
     iam_policy_description
-    iam_policy_name
+    iam_policy_name_prefix
     iam_policy_path
     iam_role_assume_role_policy
     iam_role_description
     iam_role_force_detach_policies
     iam_role_max_session_duration
-    iam_role_name
+    iam_role_name_prefix
     iam_role_permissions_boundary
     tags
 ## Required
@@ -42,17 +42,17 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
     key_enable_key_rotation
     key_usage
     key_is_enabled
-    key_name
+    key_name_prefix
     cloudwatch_name_prefix
     cloudwatch_retention_in_days
     iam_policy_description
-    iam_policy_name
+    iam_policy_name_prefix
     iam_policy_path
     iam_role_assume_role_policy
     iam_role_description
     iam_role_force_detach_policies
     iam_role_max_session_duration
-    iam_role_name
+    iam_role_name_prefix
     iam_role_permissions_boundary
     tags
 # Outputs

--- a/modules/aws/flow_logs/README.md
+++ b/modules/aws/flow_logs/README.md
@@ -8,8 +8,6 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
 
     module "flow_logs" {
         source = "github.com/thinkstack-co/terraform-modules//modules/aws/flow_logs"
-
-        aws_region = var.aws_region
     }
 
 # Variables
@@ -32,10 +30,9 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
     iam_role_max_session_duration
     iam_role_name
     iam_role_permissions_boundary
-    aws_region
     tags
 ## Required
-    aws_region
+    N/A
 
 ## Optional
     key_bypass_policy_lockout_safety_check

--- a/modules/aws/flow_logs/README.md
+++ b/modules/aws/flow_logs/README.md
@@ -8,6 +8,8 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
 
     module "flow_logs" {
         source = "github.com/thinkstack-co/terraform-modules//modules/aws/flow_logs"
+
+        flow_vpc_id = "vpc-42718oh421"
     }
 
 # Variables
@@ -30,9 +32,14 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
     iam_role_max_session_duration
     iam_role_name_prefix
     iam_role_permissions_boundary
+    flow_log_destination_type
+    flow_log_format
+    flow_max_aggregation_interval
+    flow_traffic_type
+    flow_vpc_id
     tags
 ## Required
-    N/A
+    flow_vpc_id
 
 ## Optional
     key_bypass_policy_lockout_safety_check
@@ -54,6 +61,10 @@ This module sets up each componenet required to capture ENI Flow Logs with the p
     iam_role_max_session_duration
     iam_role_name_prefix
     iam_role_permissions_boundary
+    flow_log_destination_type
+    flow_log_format
+    flow_max_aggregation_interval
+    flow_traffic_type
     tags
 # Outputs
     arn

--- a/modules/aws/flow_logs/examples/main.tf
+++ b/modules/aws/flow_logs/examples/main.tf
@@ -1,0 +1,4 @@
+module "flow_logs" {
+    source = "github.com/thinkstack-co/terraform-modules//modules/aws/flow_logs"
+    
+}

--- a/modules/aws/flow_logs/examples/main.tf
+++ b/modules/aws/flow_logs/examples/main.tf
@@ -1,4 +1,5 @@
 module "flow_logs" {
     source = "github.com/thinkstack-co/terraform-modules//modules/aws/flow_logs"
     
+    flow_vpc_id = "vpc-42718oh421"
 }

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -71,7 +71,7 @@ data "aws_iam_role" "role" {
   assume_role_policy    = var.iam_role_assume_role_policy
   description           = var.iam_role_description
   # force_detach_policies = var.iam_role_force_detach_policies
-  max_session_duration  = var.iam_role_max_session_duration
+  # max_session_duration  = var.iam_role_max_session_duration
   name                  = var.iam_role_name
-  permissions_boundary  = var.iam_role_permissions_boundary
+  # permissions_boundary  = var.iam_role_permissions_boundary
 }

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -32,7 +32,7 @@ resource "aws_kms_key" "key" {
             "Sid" = "Enable IAM User Permissions",
             "Effect" = "Allow",
             "Principal" = {
-                "AWS" = "arn:aws:iam::${account_id}:root"
+                "AWS" = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
             },
             "Action" = "kms:*",
             "Resource" = "*"

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -8,10 +8,6 @@ terraform {
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-output "account_id" {
-  value = data.aws_caller_identity.current.account_id
-}
-
 ###########################
 # KMS Encryption Key
 ###########################

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -13,7 +13,6 @@ data "aws_region" "current" {}
 ###########################
 
 resource "aws_kms_key" "key" {
-  # bypass_policy_lockout_safety_check = var.key_bypass_policy_lockout_safety_check
   customer_master_key_spec           = var.key_customer_master_key_spec
   description                        = var.key_description
   deletion_window_in_days            = var.key_deletion_window_in_days
@@ -80,10 +79,7 @@ resource "aws_iam_policy" "policy" {
   name_prefix = var.iam_policy_name_prefix
   path        = var.iam_policy_path
   tags        = var.tags
-
-  # Terraform's "jsonencode" function converts a
-  # Terraform expression result to valid JSON syntax.
-  policy = jsonencode({
+  policy      = jsonencode({
     Version = "2012-10-17",
     Statement = [{
         Effect = "Allow",
@@ -128,7 +124,6 @@ resource "aws_flow_log" "vpc_flow" {
   iam_role_arn             = aws_iam_role.role.arn
   log_destination_type     = var.flow_log_destination_type
   log_destination          = aws_cloudwatch_log_group.log_group.arn
-  # log_format               = var.flow_log_format
   max_aggregation_interval = var.flow_max_aggregation_interval
   tags                     = var.tags
   traffic_type             = var.flow_traffic_type

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -77,7 +77,7 @@ resource "aws_cloudwatch_log_group" "log_group" {
 ###########################
 resource "aws_iam_policy" "policy" {
   description = var.iam_policy_description
-  name        = var.iam_policy_name
+  name_prefix = var.iam_policy_name_prefix
   path        = var.iam_policy_path
   tags        = var.tags
 
@@ -110,6 +110,6 @@ resource "aws_iam_role" "role" {
   description           = var.iam_role_description
   force_detach_policies = var.iam_role_force_detach_policies
   max_session_duration  = var.iam_role_max_session_duration
-  name                  = var.iam_role_name
+  name_prefix           = var.iam_role_name_prefix
   permissions_boundary  = var.iam_role_permissions_boundary
 }

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -29,7 +29,7 @@ resource "aws_kms_alias" "alias" {
 
 resource "aws_cloudwatch_log_group" "log_group" {
   kms_key_id        = aws_kms_key.key.arn
-  name_prefix       = var.cloudwatch_name
+  name_prefix       = var.cloudwatch_name_prefix
   retention_in_days = var.cloudwatch_retention_in_days
   tags              = var.tags
 }
@@ -67,11 +67,11 @@ resource "aws_iam_policy" "policy" {
 # IAM Role
 ###########################
 
-data "aws_iam_role" "role" {
+resource "aws_iam_role" "role" {
   assume_role_policy    = var.iam_role_assume_role_policy
   description           = var.iam_role_description
-  # force_detach_policies = var.iam_role_force_detach_policies
-  # max_session_duration  = var.iam_role_max_session_duration
+  force_detach_policies = var.iam_role_force_detach_policies
+  max_session_duration  = var.iam_role_max_session_duration
   name                  = var.iam_role_name
-  # permissions_boundary  = var.iam_role_permissions_boundary
+  permissions_boundary  = var.iam_role_permissions_boundary
 }

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -14,9 +14,8 @@ resource "aws_kms_key" "key" {
   enable_key_rotation                = var.key_enable_key_rotation
   key_usage                          = var.key_usage
   is_enabled                         = var.key_is_enabled
-  # policy                             = var.key_policy
+  policy                             = var.key_policy
   tags                               = var.tags
-  policy                             = var.policy
 }
 
 resource "aws_kms_alias" "alias" {

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -7,7 +7,7 @@ terraform {
 ###########################
 
 resource "aws_kms_key" "key" {
-  bypass_policy_lockout_safety_check = var.key_bypass_policy_lockout_safety_check
+  # bypass_policy_lockout_safety_check = var.key_bypass_policy_lockout_safety_check
   customer_master_key_spec           = var.key_customer_master_key_spec
   description                        = var.key_description
   deletion_window_in_days            = var.key_deletion_window_in_days
@@ -70,7 +70,7 @@ resource "aws_iam_policy" "policy" {
 data "aws_iam_role" "role" {
   assume_role_policy    = var.assume_role_policy
   description           = var.description
-  force_detach_policies = var.force_detach_policies
+  # force_detach_policies = var.force_detach_policies
   max_session_duration  = var.max_session_duration
   name                  = var.name
   permissions_boundary  = var.permissions_boundary

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -14,8 +14,32 @@ resource "aws_kms_key" "key" {
   enable_key_rotation                = var.key_enable_key_rotation
   key_usage                          = var.key_usage
   is_enabled                         = var.key_is_enabled
-  policy                             = var.key_policy
+  # policy                             = var.key_policy
   tags                               = var.tags
+  policy = jsonencode({
+    "Version" = "2012-10-17",
+    "Statement" = [
+        {
+            "Effect" = "Allow",
+            "Principal" = {
+                "Service" = "logs.${var.aws_region}.amazonaws.com"
+            },
+            "Action" = [
+                "kms:Encrypt*",
+                "kms:Decrypt*",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:Describe*"
+            ],
+            "Resource" = "*",
+            "Condition" = {
+                "ArnEquals" = {
+                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:*:*:log-group:*"
+                }
+            }
+        }
+    ]
+})
 }
 
 resource "aws_kms_alias" "alias" {

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -6,7 +6,6 @@ terraform {
 # KMS Encryption Key
 ###########################
 
-/* Commented out the KMS key for now in order to further test the correct implementation
 resource "aws_kms_key" "key" {
   # bypass_policy_lockout_safety_check = var.key_bypass_policy_lockout_safety_check
   customer_master_key_spec           = var.key_customer_master_key_spec
@@ -17,53 +16,20 @@ resource "aws_kms_key" "key" {
   is_enabled                         = var.key_is_enabled
   # policy                             = var.key_policy
   tags                               = var.tags
-  policy                             = jsonencode({
-    "Version": "2012-10-17",
-        "Id": "key-default-1",
-        "Statement": [
-            {
-                "Sid": "Enable IAM User Permissions",
-                "Effect": "Allow",
-                "Principal": {
-                    "AWS": "arn:aws:iam::${account_id}:root"
-                },
-                "Action": "kms:*",
-                "Resource": "*"
-            },
-            {
-                "Effect": "Allow",
-                "Principal": {
-                    "Service": "logs.${aws_region}.amazonaws.com"
-                },
-                "Action": [
-                    "kms:Encrypt*",
-                    "kms:Decrypt*",
-                    "kms:ReEncrypt*",
-                    "kms:GenerateDataKey*",
-                    "kms:Describe*"
-                ],
-                "Resource": "*",
-                "Condition": {
-                    "ArnEquals": {
-                        "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:${aws_region}:${account_id}:${aws_cloudwatch_log_group.log_group.name}:log-group-name"
-                    }
-                }
-            }    
-        ]
-    })
+  policy                             = var.policy
 }
 
 resource "aws_kms_alias" "alias" {
   name          = var.key_name
   target_key_id = aws_kms_key.key.key_id
-} */
+}
 
 ###########################
 # CloudWatch Log Group
 ###########################
 
 resource "aws_cloudwatch_log_group" "log_group" {
-  # kms_key_id        = aws_kms_key.key.arn
+  kms_key_id        = aws_kms_key.key.arn
   name_prefix       = var.cloudwatch_name_prefix
   retention_in_days = var.cloudwatch_retention_in_days
   tags              = var.tags

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -2,6 +2,15 @@ terraform {
   required_version = ">= 0.15.0"
 }
 
+#####
+# Data Sources
+#####
+data "aws_caller_identity" "current" {}
+
+output "account_id" {
+  value = data.aws_caller_identity.current.account_id
+}
+
 ###########################
 # KMS Encryption Key
 ###########################
@@ -19,6 +28,15 @@ resource "aws_kms_key" "key" {
   policy = jsonencode({
     "Version" = "2012-10-17",
     "Statement" = [
+        {
+            "Sid" = "Enable IAM User Permissions",
+            "Effect" = "Allow",
+            "Principal" = {
+                "AWS" = "arn:aws:iam::${account_id}:root"
+            },
+            "Action" = "kms:*",
+            "Resource" = "*"
+        },
         {
             "Effect" = "Allow",
             "Principal" = {

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -114,6 +114,11 @@ resource "aws_iam_role" "role" {
   permissions_boundary  = var.iam_role_permissions_boundary
 }
 
+resource "aws_iam_role_policy_attachment" "role_attach" {
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.policy.arn
+}
+
 
 ###########################
 # VPC Flow Log

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -123,7 +123,7 @@ resource "aws_flow_log" "vpc_flow" {
   iam_role_arn             = aws_iam_role.role.arn
   log_destination_type     = var.flow_log_destination_type
   log_destination          = aws_cloudwatch_log_group.log_group.arn
-  log_format               = var.flow_log_format
+  # log_format               = var.flow_log_format
   max_aggregation_interval = var.flow_max_aggregation_interval
   tags                     = var.tags
   traffic_type             = var.flow_traffic_type

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -113,3 +113,19 @@ resource "aws_iam_role" "role" {
   name_prefix           = var.iam_role_name_prefix
   permissions_boundary  = var.iam_role_permissions_boundary
 }
+
+
+###########################
+# VPC Flow Log
+###########################
+
+resource "aws_flow_log" "vpc_flow" {
+  iam_role_arn             = aws_iam_role.role.arn
+  log_destination_type     = var.flow_log_destination_type
+  log_destination          = aws_cloudwatch_log_group.log_group.arn
+  log_format               = var.flow_log_format
+  max_aggregation_interval = var.flow_max_aggregation_interval
+  tags                     = var.tags
+  traffic_type             = var.flow_traffic_type
+  vpc_id                   = var.flow_vpc_id
+}

--- a/modules/aws/flow_logs/main.tf
+++ b/modules/aws/flow_logs/main.tf
@@ -68,10 +68,10 @@ resource "aws_iam_policy" "policy" {
 ###########################
 
 data "aws_iam_role" "role" {
-  assume_role_policy    = var.assume_role_policy
-  description           = var.description
-  # force_detach_policies = var.force_detach_policies
-  max_session_duration  = var.max_session_duration
-  name                  = var.name
-  permissions_boundary  = var.permissions_boundary
+  assume_role_policy    = var.iam_role_assume_role_policy
+  description           = var.iam_role_description
+  # force_detach_policies = var.iam_role_force_detach_policies
+  max_session_duration  = var.iam_role_max_session_duration
+  name                  = var.iam_role_name
+  permissions_boundary  = var.iam_role_permissions_boundary
 }

--- a/modules/aws/flow_logs/outputs.tf
+++ b/modules/aws/flow_logs/outputs.tf
@@ -1,0 +1,4 @@
+output "arn" {
+    description = "ARN of the cloudwatch log group used for flow logs"
+    value       = aws_cloudwatch_log_group.log_group[*].id
+}

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -145,10 +145,6 @@ variable "iam_role_permissions_boundary" {
 # General Use Variables
 ###############################################################
 
-/* variable "aws_region" {
-  description = "(Required) The AWS region the resource is deployed within."
-} */
-
 variable "tags" {
   description = "(Optional) A mapping of tags to assign to the object."
   default     = {

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -62,7 +62,7 @@ variable "cloudwatch_name_prefix" {
 
 variable "cloudwatch_retention_in_days" {
   description = "(Optional) Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire."
-  default     = 60
+  default     = 365
   type        = string
 }
 

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -52,8 +52,32 @@ variable "key_name" {
 
 variable "key_policy" {
   description = "(Optional) A valid policy JSON document. Although this is a key policy, not an IAM policy, an aws_iam_policy_document, in the form that designates a principal, can be used. For more information about building policy documents with Terraform, see the AWS IAM Policy Document Guide."
-  default     =  null
+  # default     =  null
   type        = string
+  default = jsonencode({
+    "Version" = "2012-10-17",
+    "Statement" = [
+        {
+            "Effect" = "Allow",
+            "Principal" = {
+                "Service" = "logs.${var.aws_region}.amazonaws.com"
+            },
+            "Action" = [
+                "kms:Encrypt*",
+                "kms:Decrypt*",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:Describe*"
+            ],
+            "Resource" = "*",
+            "Condition" = {
+                "ArnEquals" = {
+                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:*:*:log-group:*"
+                }
+            }
+        }
+    ]
+})
 }
 
 ###########################

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -90,7 +90,7 @@ variable "iam_policy_name" {
 
 variable "iam_policy_path" {
     type = string
-    description = "(Optional, default "/") Path in which to create the policy. See IAM Identifiers for more information."
+    description = "(Optional, default '/') Path in which to create the policy. See IAM Identifiers for more information."
     default = "/"
 }
 

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -145,9 +145,9 @@ variable "iam_role_permissions_boundary" {
 # General Use Variables
 ###############################################################
 
-variable "aws_region" {
+/* variable "aws_region" {
   description = "(Required) The AWS region the resource is deployed within."
-}
+} */
 
 variable "tags" {
   description = "(Optional) A mapping of tags to assign to the object."

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -76,9 +76,9 @@ variable "iam_policy_description" {
     type        = string
 }
 
-variable "iam_policy_name" {
-    description = "(Optional, Forces new resource) The name of the policy. If omitted, Terraform will assign a random, unique name."
-    default     = "flow_log_policy"
+variable "iam_policy_name_prefix" {
+    description = "(Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with name."
+    default     = "flow_log_policy_"
     type        = string
 }
 
@@ -129,10 +129,10 @@ variable "iam_role_max_session_duration" {
   default     = 3600
 }
 
-variable "iam_role_name" {
+variable "iam_role_name_prefix" {
   type        = string
-  description = "(Required) The friendly IAM role name to match."
-  default     = "flow_logs_role"
+  description = "(Required, Forces new resource) Creates a unique friendly name beginning with the specified prefix. Conflicts with name."
+  default     = "flow_logs_role_"
 }
 
 variable "iam_role_permissions_boundary" {

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -2,7 +2,7 @@
 # KMS Encryption Key
 ###########################
 
-/* variable "key_bypass_policy_lockout_safety_check" {
+variable "key_bypass_policy_lockout_safety_check" {
     description = "(Optional) Specifies whether to disable the policy lockout check performed when creating or updating the key's policy. Setting this value to true increases the risk that the CMK becomes unmanageable. For more information, refer to the scenario in the Default Key Policy section in the AWS Key Management Service Developer Guide. Defaults to false."
     default     = false
     type        = bool
@@ -54,7 +54,7 @@ variable "key_policy" {
   description = "(Optional) A valid policy JSON document. Although this is a key policy, not an IAM policy, an aws_iam_policy_document, in the form that designates a principal, can be used. For more information about building policy documents with Terraform, see the AWS IAM Policy Document Guide."
   default     =  null
   type        = string
-} */
+}
 
 ###########################
 # CloudWatch Log Group

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -53,30 +53,7 @@ variable "key_name" {
 variable "key_policy" {
   description = "(Optional) A valid policy JSON document. Although this is a key policy, not an IAM policy, an aws_iam_policy_document, in the form that designates a principal, can be used. For more information about building policy documents with Terraform, see the AWS IAM Policy Document Guide."
   type        = string
-  default = jsonencode({
-    "Version" = "2012-10-17",
-    "Statement" = [
-        {
-            "Effect" = "Allow",
-            "Principal" = {
-                "Service" = "logs.${var.aws_region}.amazonaws.com"
-            },
-            "Action" = [
-                "kms:Encrypt*",
-                "kms:Decrypt*",
-                "kms:ReEncrypt*",
-                "kms:GenerateDataKey*",
-                "kms:Describe*"
-            ],
-            "Resource" = "*",
-            "Condition" = {
-                "ArnEquals" = {
-                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:*:*:log-group:*"
-                }
-            }
-        }
-    ]
-})
+  default     = null
 }
 
 ###########################

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -2,7 +2,7 @@
 # KMS Encryption Key
 ###########################
 
-variable "key_bypass_policy_lockout_safety_check" {
+/* variable "key_bypass_policy_lockout_safety_check" {
     description = "(Optional) Specifies whether to disable the policy lockout check performed when creating or updating the key's policy. Setting this value to true increases the risk that the CMK becomes unmanageable. For more information, refer to the scenario in the Default Key Policy section in the AWS Key Management Service Developer Guide. Defaults to false."
     default     = false
     type        = bool
@@ -54,7 +54,7 @@ variable "key_policy" {
   description = "(Optional) A valid policy JSON document. Although this is a key policy, not an IAM policy, an aws_iam_policy_document, in the form that designates a principal, can be used. For more information about building policy documents with Terraform, see the AWS IAM Policy Document Guide."
   default     =  null
   type        = string
-}
+} */
 
 ###########################
 # CloudWatch Log Group
@@ -150,6 +150,10 @@ variable "iam_role_permissions_boundary" {
 ###############################################################
 # General Use Variables
 ###############################################################
+
+variable "aws_region" {
+  description = "(Required) The AWS region the resource is deployed within."
+}
 
 variable "tags" {
   description = "(Optional) A mapping of tags to assign to the object."

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -98,7 +98,7 @@ variable "iam_policy_path" {
 # IAM Role
 ###########################
 
-variable "assume_role_policy" {
+variable "iam_role_assume_role_policy" {
   type        = string
   description = "(Required) The policy that grants an entity permission to assume the role."
   default = <<POLICY
@@ -117,31 +117,31 @@ variable "assume_role_policy" {
 POLICY
 }
 
-variable "description" {
+variable "iam_role_description" {
   type        = string
   description = "(Optional) The description of the role."
   default     = "Role utilized for EC2 instances ENI flow logs. This role allows creation of log streams and adding logs to the log streams in cloudwatch"
 }
 
-variable "force_detach_policies" {
+variable "iam_role_force_detach_policies" {
   type        = string
   description = "(Optional) Specifies to force detaching any policies the role has before destroying it. Defaults to false."
   default     = false
 }
 
-variable "max_session_duration" {
+variable "iam_role_max_session_duration" {
   type        = string
   description = "(Optional) The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours."
   default     = 3600
 }
 
-variable "name" {
+variable "iam_role_name" {
   type        = string
   description = "(Required) The friendly IAM role name to match."
   default     = "flow_logs_role"
 }
 
-variable "permissions_boundary" {
+variable "iam_role_permissions_boundary" {
   type        = string
   description = "(Optional) The ARN of the policy that is used to set the permissions boundary for the role."
   default     = ""

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -46,7 +46,7 @@ variable "key_is_enabled" {
 
 variable "key_name_prefix" {
   description = "(Optional) Creates an unique alias beginning with the specified prefix. The name must start with the word alias followed by a forward slash (alias/)."
-  default     = "alias/flow_logs_key"
+  default     = "alias/flow_logs_key_"
   type        = string
 }
 
@@ -56,7 +56,7 @@ variable "key_name_prefix" {
 
 variable "cloudwatch_name_prefix" {
   description = "(Optional, Forces new resource) Creates a unique name beginning with the specified prefix."
-  default     = "flow_logs"
+  default     = "flow_logs_"
   type        = string
 }
 

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -52,7 +52,6 @@ variable "key_name" {
 
 variable "key_policy" {
   description = "(Optional) A valid policy JSON document. Although this is a key policy, not an IAM policy, an aws_iam_policy_document, in the form that designates a principal, can be used. For more information about building policy documents with Terraform, see the AWS IAM Policy Document Guide."
-  # default     =  null
   type        = string
   default = jsonencode({
     "Version" = "2012-10-17",

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -44,16 +44,10 @@ variable "key_is_enabled" {
   type        = string
 }
 
-variable "key_name" {
-  description = "(Optional) The display name of the alias. The name must start with the word 'alias' followed by a forward slash"
+variable "key_name_prefix" {
+  description = "(Optional) Creates an unique alias beginning with the specified prefix. The name must start with the word alias followed by a forward slash (alias/)."
   default     = "alias/flow_logs_key"
   type        = string
-}
-
-variable "key_policy" {
-  description = "(Optional) A valid policy JSON document. Although this is a key policy, not an IAM policy, an aws_iam_policy_document, in the form that designates a principal, can be used. For more information about building policy documents with Terraform, see the AWS IAM Policy Document Guide."
-  type        = string
-  default     = null
 }
 
 ###########################

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -141,6 +141,39 @@ variable "iam_role_permissions_boundary" {
   default     = ""
 }
 
+###########################
+# CloudWatch Log Group
+###########################
+
+variable "flow_log_destination_type" {
+  type        = string
+  description = "(Optional) The type of the logging destination. Valid values: cloud-watch-logs, s3. Default: cloud-watch-logs."
+  default     = "cloud-watch-logs"
+}
+
+/* variable "flow_log_format" {
+  type        = string
+  description = "(Optional) The fields to include in the flow log record, in the order in which they should appear."
+  default     = ""
+} */
+
+variable "flow_max_aggregation_interval" {
+  type        = string
+  description = "(Optional) The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. Valid Values: 60 seconds (1 minute) or 600 seconds (10 minutes). Default: 600."
+  default     = 60
+}
+
+variable "flow_traffic_type" {
+  type        = string
+  description = "(Optional) The type of traffic to capture. Valid values: ACCEPT,REJECT, ALL."
+  default     = "ALL"
+}
+
+variable "flow_vpc_id" {
+  type        = string
+  description = "(Required) VPC ID to attach to"
+}
+
 ###############################################################
 # General Use Variables
 ###############################################################

--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -2,12 +2,6 @@
 # KMS Encryption Key
 ###########################
 
-variable "key_bypass_policy_lockout_safety_check" {
-    description = "(Optional) Specifies whether to disable the policy lockout check performed when creating or updating the key's policy. Setting this value to true increases the risk that the CMK becomes unmanageable. For more information, refer to the scenario in the Default Key Policy section in the AWS Key Management Service Developer Guide. Defaults to false."
-    default     = false
-    type        = bool
-}
-
 variable "key_customer_master_key_spec" {
     description = "(Optional) Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. Valid values: SYMMETRIC_DEFAULT, RSA_2048, RSA_3072, RSA_4096, ECC_NIST_P256, ECC_NIST_P384, ECC_NIST_P521, or ECC_SECG_P256K1. Defaults to SYMMETRIC_DEFAULT. For help with choosing a key spec, see the AWS KMS Developer Guide."
     default     = "SYMMETRIC_DEFAULT"
@@ -150,12 +144,6 @@ variable "flow_log_destination_type" {
   description = "(Optional) The type of the logging destination. Valid values: cloud-watch-logs, s3. Default: cloud-watch-logs."
   default     = "cloud-watch-logs"
 }
-
-/* variable "flow_log_format" {
-  type        = string
-  description = "(Optional) The fields to include in the flow log record, in the order in which they should appear."
-  default     = ""
-} */
 
 variable "flow_max_aggregation_interval" {
   type        = string

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -368,7 +368,7 @@ resource "aws_iam_policy" "policy" {
             "logs:DescribeLogStreams"
         ],
         Resource = [
-            "${aws_cloudwatch_log_group.log_group.arn}:*"
+            "${aws_cloudwatch_log_group.log_group[0].arn}:*"
         ]
         }]
     })

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -332,7 +332,7 @@ resource "aws_kms_key" "key" {
 resource "aws_kms_alias" "alias" {
   count         = (var.enable_vpc_flow_logs == true ? 1 : 0)
   name_prefix   = var.key_name_prefix
-  target_key_id = aws_kms_key.key.key_id
+  target_key_id = aws_kms_key.key.key_id[0]
 }
 
 ###########################

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -216,16 +216,6 @@ resource "aws_route" "workspaces_default_route_fw" {
   route_table_id         = element(aws_route_table.workspaces_route_table.*.id, count.index)
 }
 
-# data "aws_vpc_endpoint_service" "s3" {
-#   count        = var.enable_s3_endpoint ? 1 : 0
-#   service_name = "s3"
-#   # filter {
-#   #   name   = "vpc_id"
-#   #   values = [aws_vpc.vpc.id]
-#   # }
-# }
-
-
 locals {
   service_name = "com.amazonaws.${var.vpc_region}.s3"
 }

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -341,7 +341,7 @@ resource "aws_kms_alias" "alias" {
 
 resource "aws_cloudwatch_log_group" "log_group" {
   count             = (var.enable_vpc_flow_logs == true ? 1 : 0)
-  kms_key_id        = aws_kms_key.key.arn
+  kms_key_id        = aws_kms_key.key[0].arn
   name_prefix       = var.cloudwatch_name_prefix
   retention_in_days = var.cloudwatch_retention_in_days
   tags              = var.tags

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -2,6 +2,16 @@ terraform {
   required_version = ">= 0.12.0"
 }
 
+###########################
+# Data Sources
+###########################
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+###########################
+# VPC
+###########################
+
 resource "aws_vpc" "vpc" {
   cidr_block           = var.vpc_cidr
   enable_dns_hostnames = var.enable_dns_hostnames
@@ -9,6 +19,10 @@ resource "aws_vpc" "vpc" {
   instance_tenancy     = var.instance_tenancy
   tags                 = merge({ "Name" = format("%s", var.name) }, var.tags, )
 }
+
+###########################
+# Subnets
+###########################
 
 resource "aws_subnet" "private_subnets" {
   vpc_id            = aws_vpc.vpc.id
@@ -59,6 +73,10 @@ resource "aws_subnet" "workspaces_subnets" {
   tags              = merge(var.tags, ({ "Name" = format("%s-subnet-workspaces-%s", var.name, element(var.azs, count.index)) }))
 }
 
+###########################
+# Gateways
+###########################
+
 resource "aws_internet_gateway" "igw" {
   tags   = merge(var.tags, ({ "Name" = format("%s-igw", var.name) }))
   vpc_id = aws_vpc.vpc.id
@@ -88,6 +106,10 @@ resource "aws_nat_gateway" "natgw" {
   count         = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.azs)) : 0
   subnet_id     = element(aws_subnet.public_subnets.*.id, (var.single_nat_gateway ? 0 : count.index))
 }
+
+###########################
+# Route Tables and Associations
+###########################
 
 resource "aws_route_table" "private_route_table" {
   count            = length(var.azs)
@@ -253,4 +275,137 @@ resource "aws_route_table_association" "workspaces" {
   count          = length(var.workspaces_subnets_list)
   route_table_id = element(aws_route_table.workspaces_route_table.*.id, count.index)
   subnet_id      = element(aws_subnet.workspaces_subnets.*.id, count.index)
+}
+
+######################################################
+# VPC Flow Logs
+######################################################
+
+###########################
+# KMS Encryption Key
+###########################
+
+resource "aws_kms_key" "key" {
+  count                    = (var.enable_vpc_flow_logs == true ? 1 : 0)
+  customer_master_key_spec = var.key_customer_master_key_spec
+  description              = var.key_description
+  deletion_window_in_days  = var.key_deletion_window_in_days
+  enable_key_rotation      = var.key_enable_key_rotation
+  key_usage                = var.key_usage
+  is_enabled               = var.key_is_enabled
+  tags                     = var.tags
+  policy                   = jsonencode({
+    "Version" = "2012-10-17",
+    "Statement" = [
+        {
+            "Sid" = "Enable IAM User Permissions",
+            "Effect" = "Allow",
+            "Principal" = {
+                "AWS" = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+            },
+            "Action" = "kms:*",
+            "Resource" = "*"
+        },
+        {
+            "Effect" = "Allow",
+            "Principal" = {
+                "Service" = "logs.${data.aws_region.current.name}.amazonaws.com"
+            },
+            "Action" = [
+                "kms:Encrypt*",
+                "kms:Decrypt*",
+                "kms:ReEncrypt*",
+                "kms:GenerateDataKey*",
+                "kms:Describe*"
+            ],
+            "Resource" = "*",
+            "Condition" = {
+                "ArnEquals" = {
+                    "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:*"
+                }
+            }
+        }
+    ]
+})
+}
+
+resource "aws_kms_alias" "alias" {
+  count         = (var.enable_vpc_flow_logs == true ? 1 : 0)
+  name_prefix   = var.key_name_prefix
+  target_key_id = aws_kms_key.key.key_id
+}
+
+###########################
+# CloudWatch Log Group
+###########################
+
+resource "aws_cloudwatch_log_group" "log_group" {
+  count             = (var.enable_vpc_flow_logs == true ? 1 : 0)
+  kms_key_id        = aws_kms_key.key.arn
+  name_prefix       = var.cloudwatch_name_prefix
+  retention_in_days = var.cloudwatch_retention_in_days
+  tags              = var.tags
+}
+
+###########################
+# IAM Policy
+###########################
+resource "aws_iam_policy" "policy" {
+  count       = (var.enable_vpc_flow_logs == true ? 1 : 0)
+  description = var.iam_policy_description
+  name_prefix = var.iam_policy_name_prefix
+  path        = var.iam_policy_path
+  tags        = var.tags
+  policy      = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+        Effect = "Allow",
+        Action = [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+            "logs:DescribeLogGroups",
+            "logs:DescribeLogStreams"
+        ],
+        Resource = [
+            "${aws_cloudwatch_log_group.log_group.arn}:*"
+        ]
+        }]
+    })
+}
+
+###########################
+# IAM Role
+###########################
+
+resource "aws_iam_role" "role" {
+  count                 = (var.enable_vpc_flow_logs == true ? 1 : 0)
+  assume_role_policy    = var.iam_role_assume_role_policy
+  description           = var.iam_role_description
+  force_detach_policies = var.iam_role_force_detach_policies
+  max_session_duration  = var.iam_role_max_session_duration
+  name_prefix           = var.iam_role_name_prefix
+  permissions_boundary  = var.iam_role_permissions_boundary
+}
+
+resource "aws_iam_role_policy_attachment" "role_attach" {
+  count      = (var.enable_vpc_flow_logs == true ? 1 : 0)
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.policy.arn
+}
+
+
+###########################
+# VPC Flow Log
+###########################
+
+resource "aws_flow_log" "vpc_flow" {
+  count                    = (var.enable_vpc_flow_logs == true ? 1 : 0)
+  iam_role_arn             = aws_iam_role.role.arn
+  log_destination_type     = var.flow_log_destination_type
+  log_destination          = aws_cloudwatch_log_group.log_group.arn
+  max_aggregation_interval = var.flow_max_aggregation_interval
+  tags                     = var.tags
+  traffic_type             = var.flow_traffic_type
+  vpc_id                   = var.flow_vpc_id
 }

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -217,7 +217,7 @@ resource "aws_route" "workspaces_default_route_fw" {
 }
 
 locals {
-  service_name = "com.amazonaws.${var.vpc_region}.s3"
+  service_name = "com.amazonaws.${var.data.aws_region.current.name}.s3"
 }
 resource "aws_vpc_endpoint" "s3" {
   count        = var.enable_s3_endpoint ? 1 : 0

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -390,8 +390,8 @@ resource "aws_iam_role" "role" {
 
 resource "aws_iam_role_policy_attachment" "role_attach" {
   count      = (var.enable_vpc_flow_logs == true ? 1 : 0)
-  role       = aws_iam_role.role.name
-  policy_arn = aws_iam_policy.policy.arn
+  role       = aws_iam_role.role[0].name
+  policy_arn = aws_iam_policy.policy[0].arn
 }
 
 
@@ -401,9 +401,9 @@ resource "aws_iam_role_policy_attachment" "role_attach" {
 
 resource "aws_flow_log" "vpc_flow" {
   count                    = (var.enable_vpc_flow_logs == true ? 1 : 0)
-  iam_role_arn             = aws_iam_role.role.arn
+  iam_role_arn             = aws_iam_role.role[0].arn
   log_destination_type     = var.flow_log_destination_type
-  log_destination          = aws_cloudwatch_log_group.log_group.arn
+  log_destination          = aws_cloudwatch_log_group.log_group[0].arn
   max_aggregation_interval = var.flow_max_aggregation_interval
   tags                     = var.tags
   traffic_type             = var.flow_traffic_type

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -407,5 +407,5 @@ resource "aws_flow_log" "vpc_flow" {
   max_aggregation_interval = var.flow_max_aggregation_interval
   tags                     = var.tags
   traffic_type             = var.flow_traffic_type
-  vpc_id                   = var.flow_vpc_id
+  vpc_id                   = aws_vpc.vpc.id
 }

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -332,7 +332,7 @@ resource "aws_kms_key" "key" {
 resource "aws_kms_alias" "alias" {
   count         = (var.enable_vpc_flow_logs == true ? 1 : 0)
   name_prefix   = var.key_name_prefix
-  target_key_id = aws_kms_key.key.key_id[0]
+  target_key_id = aws_kms_key.key[0].key_id
 }
 
 ###########################

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -8,6 +8,10 @@ terraform {
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+locals {
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+}
+
 ###########################
 # VPC
 ###########################
@@ -216,9 +220,6 @@ resource "aws_route" "workspaces_default_route_fw" {
   route_table_id         = element(aws_route_table.workspaces_route_table.*.id, count.index)
 }
 
-locals {
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
-}
 resource "aws_vpc_endpoint" "s3" {
   count        = var.enable_s3_endpoint ? 1 : 0
   vpc_id       = aws_vpc.vpc.id

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -217,7 +217,7 @@ resource "aws_route" "workspaces_default_route_fw" {
 }
 
 locals {
-  service_name = "com.amazonaws.${var.data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
 }
 resource "aws_vpc_endpoint" "s3" {
   count        = var.enable_s3_endpoint ? 1 : 0

--- a/modules/aws/vpc/readme.md
+++ b/modules/aws/vpc/readme.md
@@ -48,15 +48,15 @@ Creates the following
 | fw\_dmz\_network\_interface\_id | Firewall DMZ eni id | `list` | `[]` | no |
 | fw\_network\_interface\_id | Firewall network interface id | `list` | `[]` | no |
 | instance\_tenancy | A tenancy option for instances launched into the VPC | `string` | `"default"` | no |
-| map\_public\_ip\_on\_launch | should be false if you do not want to auto-assign public IP on launch | `bool` | `true` | no |
+| map\_public\_ip\_on\_launch | (Optional) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default is false. | `bool` | `true` | no |
 | mgmt\_propagating\_vgws | A list of VGWs the mgmt route table should propagate. | `list` | `[]` | no |
 | mgmt\_subnets\_list | A list of mgmt subnets inside the VPC. | `list` | <pre>[<br>  "10.11.61.0/24",<br>  "10.11.62.0/24",<br>  "10.11.63.0/24"<br>]</pre> | no |
-| name | Name to be used on all the resources as identifier | `string` | `"terraform"` | no |
+| name | (Required) Name to be tagged on all of the resources as an identifier | `string` | `null` | yes |
 | private\_propagating\_vgws | A list of VGWs the private route table should propagate. | `list` | `[]` | no |
 | private\_subnets\_list | A list of private subnets inside the VPC. | `list` | <pre>[<br>  "10.11.1.0/24",<br>  "10.11.2.0/24",<br>  "10.11.3.0/24"<br>]</pre> | no |
 | public\_propagating\_vgws | A list of VGWs the public route table should propagate. | `list` | `[]` | no |
 | public\_subnets\_list | A list of public subnets inside the VPC. | `list` | <pre>[<br>  "10.11.201.0/24",<br>  "10.11.202.0/24",<br>  "10.11.203.0/24"<br>]</pre> | no |
-| single\_nat\_gateway | should be true if you want to provision a single shared NAT Gateway across all of your private networks | `bool` | `false` | no |
+| single\_nat\_gateway | (Optional) A boolean flag to enable/disable use of only a single shared NAT Gateway across all of your private networks. Defaults False. | `bool` | `false` | no |
 | tags | A map of tags to add to all resources | `map` | <pre>{<br>  "environment": "prod",<br>  "project": "core_infrastructure",<br>  "terraform": "true"<br>}</pre> | no |
 | vpc\_cidr | The CIDR block for the VPC | `string` | `"10.11.0.0/16"` | no |
 | vpc\_region | The region for the VPC | `any` | n/a | yes |

--- a/modules/aws/vpc/readme.md
+++ b/modules/aws/vpc/readme.md
@@ -39,11 +39,12 @@ Creates the following
 | db\_subnets\_list | A list of database subnets inside the VPC. | `list` | <pre>[<br>  "10.11.11.0/24",<br>  "10.11.12.0/24",<br>  "10.11.13.0/24"<br>]</pre> | no |
 | dmz\_propagating\_vgws | A list of VGWs the DMZ route table should propagate. | `list` | `[]` | no |
 | dmz\_subnets\_list | A list of DMZ subnets inside the VPC. | `list` | <pre>[<br>  "10.11.101.0/24",<br>  "10.11.102.0/24",<br>  "10.11.103.0/24"<br>]</pre> | no |
-| enable\_dns\_hostnames | should be true if you want to use private DNS within the VPC | `bool` | `true` | no |
-| enable\_dns\_support | should be true if you want to use private DNS within the VPC | `bool` | `true` | no |
-| enable\_firewall | should be true if you are using a firewall to NAT traffic for the private subnets | `bool` | `false` | no |
-| enable\_nat\_gateway | should be true if you want to provision NAT Gateways for each of your private networks | `bool` | `true` | no |
-| enable\_s3\_endpoint | should be true if you want to provision an S3 endpoint to the VPC | `bool` | `false` | no |
+| enable\_dns\_hostnames | (Optional) A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false. | `bool` | `true` | no |
+| enable\_dns\_support | (Optional) A boolean flag to enable/disable DNS support in the VPC. Defaults true. | `bool` | `true` | no |
+| enable\_firewall | (Optional) A boolean flag to enable/disable the use of a firewall instance within the VPC. Defaults False. | `bool` | `false` | no |
+| enable\_nat\_gateway | (Optional) A boolean flag to enable/disable the use of NAT gateways in the private subnets. Defaults True. | `bool` | `true` | no |
+| enable\_s3\_endpoint | (Optional) A boolean flag to enable/disable the use of a S3 endpoint with the VPC. Defaults False | `bool` | `false` | no |
+| enable\_vpc\_flow\_logs | (Optional) A boolean flag to enable/disable the use of VPC flow logs with the VPC. Defaults True. | `bool` | `true` | no |
 | fw\_dmz\_network\_interface\_id | Firewall DMZ eni id | `list` | `[]` | no |
 | fw\_network\_interface\_id | Firewall network interface id | `list` | `[]` | no |
 | instance\_tenancy | A tenancy option for instances launched into the VPC | `string` | `"default"` | no |

--- a/modules/aws/vpc/readme.md
+++ b/modules/aws/vpc/readme.md
@@ -1,4 +1,6 @@
 ## Description
+Module which builds out a VPC with multiple subnets for network segmentation, associated routes, gateways, and flow logs for all instances within the VPC.
+
 Creates the following
 -   VPC
 -   Two private subnets, one in each of two AZs
@@ -9,6 +11,12 @@ Creates the following
 -   Two EIPs attached to the NAT gateways
 -   One internet gateway
 -   Three route tables. One for the public subnets, and two for each of the private subnets
+-   Cloudwatch group
+-   KMS key
+-   KMS alias
+-   IAM policy
+-   IAM role
+-   VPC flow log
 
 ## Requirements
 

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -1,3 +1,22 @@
+###########################
+# VPC
+###########################
+
+###########################
+# Subnets
+###########################
+
+
+###########################
+# Gateways
+###########################
+
+###########################
+# Route Tables and Associations
+###########################
+
+
+
 variable "azs" {
   description = "A list of Availability zones in the region"
   default     = ["us-east-2a", "us-east-2b", "us-east-2c"]

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -286,13 +286,13 @@ variable "flow_traffic_type" {
 
 
 variable "enable_firewall" {
-  description = "(Optional) should be true if you are using a firewall to NAT traffic for the private subnets"
+  description = "(Optional) A boolean flag to enable/disable the use of a firewall instance within the VPC. Defaults False."
   default     = false
   type        = bool
 }
 
 variable "enable_nat_gateway" {
-  description = "(Optional) should be true if you want to provision NAT Gateways for each of your private networks"
+  description = "(Optional) A boolean flag to enable/disable the use of NAT gateways in the private subnets. Defaults True"
   default     = true
   type        = bool
 }

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -29,17 +29,6 @@ variable "instance_tenancy" {
 # Subnets
 ###########################
 
-
-###########################
-# Gateways
-###########################
-
-###########################
-# Route Tables and Associations
-###########################
-
-
-
 variable "azs" {
   description = "A list of Availability zones in the region"
   default     = ["us-east-2a", "us-east-2b", "us-east-2c"]
@@ -50,14 +39,53 @@ variable "db_subnets_list" {
   default     = ["10.11.11.0/24", "10.11.12.0/24", "10.11.13.0/24"]
 }
 
-variable "db_propagating_vgws" {
-  description = "A list of VGWs the db route table should propagate."
-  default     = []
-}
-
 variable "dmz_subnets_list" {
   description = "A list of DMZ subnets inside the VPC."
   default     = ["10.11.101.0/24", "10.11.102.0/24", "10.11.103.0/24"]
+}
+
+variable "map_public_ip_on_launch" {
+  description = "(Optional) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default is false."
+  default     = true
+  type        = bool
+}
+
+variable "mgmt_subnets_list" {
+  description = "A list of mgmt subnets inside the VPC."
+  default     = ["10.11.61.0/24", "10.11.62.0/24", "10.11.63.0/24"]
+}
+
+variable "private_subnets_list" {
+  description = "A list of private subnets inside the VPC."
+  default     = ["10.11.1.0/24", "10.11.2.0/24", "10.11.3.0/24"]
+}
+
+variable "public_subnets_list" {
+  description = "A list of public subnets inside the VPC."
+  default     = ["10.11.201.0/24", "10.11.202.0/24", "10.11.203.0/24"]
+}
+
+variable "workspaces_subnets_list" {
+  description = "A list of workspaces subnets inside the VPC."
+  default     = ["10.11.21.0/24", "10.11.22.0/24", "10.11.23.0/24"]
+}
+
+###########################
+# Gateways
+###########################
+
+variable "single_nat_gateway" {
+  description = "(Optional) A boolean flag to enable/disable use of only a single shared NAT Gateway across all of your private networks. Defaults False."
+  default     = false
+}
+
+###########################
+# Route Tables and Associations
+###########################
+
+variable "db_propagating_vgws" {
+  description = "A list of VGWs the db route table should propagate."
+  default     = []
 }
 
 variable "dmz_propagating_vgws" {
@@ -76,30 +104,9 @@ variable "fw_network_interface_id" {
   default     = []
 }
 
-variable "map_public_ip_on_launch" {
-  description = "(Optional) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default is false."
-  default     = true
-  type        = bool
-}
-
-variable "mgmt_subnets_list" {
-  description = "A list of mgmt subnets inside the VPC."
-  default     = ["10.11.61.0/24", "10.11.62.0/24", "10.11.63.0/24"]
-}
-
 variable "mgmt_propagating_vgws" {
   description = "A list of VGWs the mgmt route table should propagate."
   default     = []
-}
-
-variable "name" {
-  description = "(Required) Name to be tagged on all of the resources as an identifier"
-  type        = string
-}
-
-variable "private_subnets_list" {
-  description = "A list of private subnets inside the VPC."
-  default     = ["10.11.1.0/24", "10.11.2.0/24", "10.11.3.0/24"]
 }
 
 variable "private_propagating_vgws" {
@@ -107,29 +114,14 @@ variable "private_propagating_vgws" {
   default     = []
 }
 
-variable "public_subnets_list" {
-  description = "A list of public subnets inside the VPC."
-  default     = ["10.11.201.0/24", "10.11.202.0/24", "10.11.203.0/24"]
-}
-
 variable "public_propagating_vgws" {
   description = "A list of VGWs the public route table should propagate."
   default     = []
 }
 
-variable "single_nat_gateway" {
-  description = "(Optional) A boolean flag to enable/disable use of only a single shared NAT Gateway across all of your private networks. Defaults False."
-  default     = false
-}
-
 variable "vpc_region" {
   description = "The region for the VPC"
   type        = string
-}
-
-variable "workspaces_subnets_list" {
-  description = "A list of workspaces subnets inside the VPC."
-  default     = ["10.11.21.0/24", "10.11.22.0/24", "10.11.23.0/24"]
 }
 
 variable "workspaces_propagating_vgws" {
@@ -305,8 +297,6 @@ variable "flow_traffic_type" {
 # General Use Variables
 ###############################################################
 
-
-
 variable "enable_firewall" {
   description = "(Optional) A boolean flag to enable/disable the use of a firewall instance within the VPC. Defaults False."
   default     = false
@@ -329,6 +319,11 @@ variable "enable_vpc_flow_logs" {
   description = "(Optional) A boolean flag to enable/disable the use of VPC flow logs with the VPC. Defaults True."
   default     = true
   type        = bool
+}
+
+variable "name" {
+  description = "(Required) Name to be tagged on all of the resources as an identifier"
+  type        = string
 }
 
 variable "tags" {

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -24,28 +24,14 @@ variable "dmz_propagating_vgws" {
 }
 
 variable "enable_dns_hostnames" {
-  description = "should be true if you want to use private DNS within the VPC"
+  description = "(Optional) A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false."
   default     = true
+  type        = bool
 }
 
 variable "enable_dns_support" {
-  description = "should be true if you want to use private DNS within the VPC"
+  description = "(Optional) A boolean flag to enable/disable DNS support in the VPC. Defaults true."
   default     = true
-}
-
-variable "enable_firewall" {
-  description = "should be true if you are using a firewall to NAT traffic for the private subnets"
-  default     = false
-}
-
-variable "enable_nat_gateway" {
-  description = "should be true if you want to provision NAT Gateways for each of your private networks"
-  default     = true
-}
-
-variable "enable_s3_endpoint" {
-  description = "should be true if you want to provision an S3 endpoint to the VPC"
-  default     = false
   type        = bool
 }
 
@@ -110,15 +96,6 @@ variable "single_nat_gateway" {
   default     = false
 }
 
-variable "tags" {
-  description = "A map of tags to add to all resources"
-  default = {
-    terraform   = "true"
-    environment = "prod"
-    project     = "core_infrastructure"
-  }
-}
-
 variable "vpc_cidr" {
   description = "The CIDR block for the VPC"
   default     = "10.11.0.0/16"
@@ -136,4 +113,208 @@ variable "workspaces_subnets_list" {
 variable "workspaces_propagating_vgws" {
   description = "A list of VGWs the workspaces route table should propagate."
   default     = []
+}
+
+###########################
+# KMS Encryption Key
+###########################
+
+variable "key_customer_master_key_spec" {
+    description = "(Optional) Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. Valid values: SYMMETRIC_DEFAULT, RSA_2048, RSA_3072, RSA_4096, ECC_NIST_P256, ECC_NIST_P384, ECC_NIST_P521, or ECC_SECG_P256K1. Defaults to SYMMETRIC_DEFAULT. For help with choosing a key spec, see the AWS KMS Developer Guide."
+    default     = "SYMMETRIC_DEFAULT"
+    type        = string
+}
+
+variable "key_description" {
+    description = "(Optional) The description of the key as viewed in AWS console."
+    default     = "CloudWatch kms key used to encrypt flow logs"
+    type        = string
+}
+
+variable "key_deletion_window_in_days" {
+    description = "(Optional) Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. Defaults to 30 days."
+    default     = 30
+    type        = number
+}
+
+variable "key_enable_key_rotation" {
+  description = "(Optional) Specifies whether key rotation is enabled. Defaults to false."
+  default     = true
+  type        = bool
+}
+
+variable "key_usage" {
+  description = "(Optional) Specifies the intended use of the key. Defaults to ENCRYPT_DECRYPT, and only symmetric encryption and decryption are supported."
+  default     = "ENCRYPT_DECRYPT"
+  type        = string
+}
+
+variable "key_is_enabled" {
+  description = "(Optional) Specifies whether the key is enabled. Defaults to true."
+  default     = true
+  type        = string
+}
+
+variable "key_name_prefix" {
+  description = "(Optional) Creates an unique alias beginning with the specified prefix. The name must start with the word alias followed by a forward slash (alias/)."
+  default     = "alias/flow_logs_key_"
+  type        = string
+}
+
+###########################
+# CloudWatch Log Group
+###########################
+
+variable "cloudwatch_name_prefix" {
+  description = "(Optional, Forces new resource) Creates a unique name beginning with the specified prefix."
+  default     = "flow_logs_"
+  type        = string
+}
+
+variable "cloudwatch_retention_in_days" {
+  description = "(Optional) Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire."
+  default     = 365
+  type        = string
+}
+
+###########################
+# IAM Policy
+###########################
+
+variable "iam_policy_description" {
+    description = "(Optional, Forces new resource) Description of the IAM policy."
+    default     = "Used with flow logs to send packet capture logs to a CloudWatch log group"
+    type        = string
+}
+
+variable "iam_policy_name_prefix" {
+    description = "(Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with name."
+    default     = "flow_log_policy_"
+    type        = string
+}
+
+variable "iam_policy_path" {
+    type = string
+    description = "(Optional, default '/') Path in which to create the policy. See IAM Identifiers for more information."
+    default = "/"
+}
+
+###########################
+# IAM Role
+###########################
+
+variable "iam_role_assume_role_policy" {
+  type        = string
+  description = "(Required) The policy that grants an entity permission to assume the role."
+  default = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "vpc-flow-logs.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+variable "iam_role_description" {
+  type        = string
+  description = "(Optional) The description of the role."
+  default     = "Role utilized for EC2 instances ENI flow logs. This role allows creation of log streams and adding logs to the log streams in cloudwatch"
+}
+
+variable "iam_role_force_detach_policies" {
+  type        = string
+  description = "(Optional) Specifies to force detaching any policies the role has before destroying it. Defaults to false."
+  default     = false
+}
+
+variable "iam_role_max_session_duration" {
+  type        = string
+  description = "(Optional) The maximum session duration (in seconds) that you want to set for the specified role. If you do not specify a value for this setting, the default maximum of one hour is applied. This setting can have a value from 1 hour to 12 hours."
+  default     = 3600
+}
+
+variable "iam_role_name_prefix" {
+  type        = string
+  description = "(Required, Forces new resource) Creates a unique friendly name beginning with the specified prefix. Conflicts with name."
+  default     = "flow_logs_role_"
+}
+
+variable "iam_role_permissions_boundary" {
+  type        = string
+  description = "(Optional) The ARN of the policy that is used to set the permissions boundary for the role."
+  default     = ""
+}
+
+###########################
+# CloudWatch Log Group
+###########################
+
+variable "flow_log_destination_type" {
+  type        = string
+  description = "(Optional) The type of the logging destination. Valid values: cloud-watch-logs, s3. Default: cloud-watch-logs."
+  default     = "cloud-watch-logs"
+}
+
+variable "flow_max_aggregation_interval" {
+  type        = string
+  description = "(Optional) The maximum interval of time during which a flow of packets is captured and aggregated into a flow log record. Valid Values: 60 seconds (1 minute) or 600 seconds (10 minutes). Default: 600."
+  default     = 60
+}
+
+variable "flow_traffic_type" {
+  type        = string
+  description = "(Optional) The type of traffic to capture. Valid values: ACCEPT,REJECT, ALL."
+  default     = "ALL"
+}
+
+variable "flow_vpc_id" {
+  type        = string
+  description = "(Required) VPC ID to attach to"
+}
+
+###############################################################
+# General Use Variables
+###############################################################
+
+
+
+variable "enable_firewall" {
+  description = "(Optional) should be true if you are using a firewall to NAT traffic for the private subnets"
+  default     = false
+  type        = bool
+}
+
+variable "enable_nat_gateway" {
+  description = "(Optional) should be true if you want to provision NAT Gateways for each of your private networks"
+  default     = true
+  type        = bool
+}
+
+variable "enable_s3_endpoint" {
+  description = "(Optional) Enables associating the S3 endpoint with the VPC"
+  default     = false
+  type        = bool
+}
+
+variable "enable_vpc_flow_logs" {
+  description = "(Optional) Enables the resources associated with building and attaching VPC flow logs to the entire VPC. "
+  default     = true
+  type        = bool
+}
+
+variable "tags" {
+  description = "(Optional) A mapping of tags to assign to the object."
+  default     = {
+    terraform   = "true"
+    created_by  = "ThinkStack"
+    environment = "prod"
+    priority    = "high"
+  }
 }

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -119,10 +119,10 @@ variable "public_propagating_vgws" {
   default     = []
 }
 
-variable "vpc_region" {
+/* variable "vpc_region" {
   description = "The region for the VPC"
   type        = string
-}
+} */
 
 variable "workspaces_propagating_vgws" {
   description = "A list of VGWs the workspaces route table should propagate."

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -292,19 +292,19 @@ variable "enable_firewall" {
 }
 
 variable "enable_nat_gateway" {
-  description = "(Optional) A boolean flag to enable/disable the use of NAT gateways in the private subnets. Defaults True"
+  description = "(Optional) A boolean flag to enable/disable the use of NAT gateways in the private subnets. Defaults True."
   default     = true
   type        = bool
 }
 
 variable "enable_s3_endpoint" {
-  description = "(Optional) Enables associating the S3 endpoint with the VPC"
+  description = "(Optional) A boolean flag to enable/disable the use of a S3 endpoint with the VPC. Defaults False"
   default     = false
   type        = bool
 }
 
 variable "enable_vpc_flow_logs" {
-  description = "(Optional) Enables the resources associated with building and attaching VPC flow logs to the entire VPC. "
+  description = "(Optional) A boolean flag to enable/disable the use of VPC flow logs with the VPC. Defaults True."
   default     = true
   type        = bool
 }

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -52,8 +52,9 @@ variable "instance_tenancy" {
 }
 
 variable "map_public_ip_on_launch" {
-  description = "should be false if you do not want to auto-assign public IP on launch"
+  description = "(Optional) Specify true to indicate that instances launched into the subnet should be assigned a public IP address. Default is false."
   default     = true
+  type        = bool
 }
 
 variable "mgmt_subnets_list" {
@@ -67,8 +68,8 @@ variable "mgmt_propagating_vgws" {
 }
 
 variable "name" {
-  description = "Name to be used on all the resources as identifier"
-  default     = "terraform"
+  description = "(Required) Name to be tagged on all of the resources as an identifier"
+  type        = string
 }
 
 variable "private_subnets_list" {
@@ -76,14 +77,14 @@ variable "private_subnets_list" {
   default     = ["10.11.1.0/24", "10.11.2.0/24", "10.11.3.0/24"]
 }
 
-variable "public_subnets_list" {
-  description = "A list of public subnets inside the VPC."
-  default     = ["10.11.201.0/24", "10.11.202.0/24", "10.11.203.0/24"]
-}
-
 variable "private_propagating_vgws" {
   description = "A list of VGWs the private route table should propagate."
   default     = []
+}
+
+variable "public_subnets_list" {
+  description = "A list of public subnets inside the VPC."
+  default     = ["10.11.201.0/24", "10.11.202.0/24", "10.11.203.0/24"]
 }
 
 variable "public_propagating_vgws" {
@@ -92,17 +93,19 @@ variable "public_propagating_vgws" {
 }
 
 variable "single_nat_gateway" {
-  description = "should be true if you want to provision a single shared NAT Gateway across all of your private networks"
+  description = "(Optional) A boolean flag to enable/disable use of only a single shared NAT Gateway across all of your private networks. Defaults False."
   default     = false
 }
 
 variable "vpc_cidr" {
   description = "The CIDR block for the VPC"
   default     = "10.11.0.0/16"
+  type        = string
 }
 
 variable "vpc_region" {
   description = "The region for the VPC"
+  type        = string
 }
 
 variable "workspaces_subnets_list" {

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -274,10 +274,10 @@ variable "flow_traffic_type" {
   default     = "ALL"
 }
 
-variable "flow_vpc_id" {
+/* variable "flow_vpc_id" {
   type        = string
   description = "(Required) VPC ID to attach to"
-}
+} */
 
 ###############################################################
 # General Use Variables

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -2,6 +2,29 @@
 # VPC
 ###########################
 
+variable "vpc_cidr" {
+  description = "The CIDR block for the VPC"
+  default     = "10.11.0.0/16"
+  type        = string
+}
+
+variable "enable_dns_hostnames" {
+  description = "(Optional) A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false."
+  default     = true
+  type        = bool
+}
+
+variable "enable_dns_support" {
+  description = "(Optional) A boolean flag to enable/disable DNS support in the VPC. Defaults true."
+  default     = true
+  type        = bool
+}
+
+variable "instance_tenancy" {
+  description = "A tenancy option for instances launched into the VPC"
+  default     = "default"
+}
+
 ###########################
 # Subnets
 ###########################
@@ -42,18 +65,6 @@ variable "dmz_propagating_vgws" {
   default     = []
 }
 
-variable "enable_dns_hostnames" {
-  description = "(Optional) A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false."
-  default     = true
-  type        = bool
-}
-
-variable "enable_dns_support" {
-  description = "(Optional) A boolean flag to enable/disable DNS support in the VPC. Defaults true."
-  default     = true
-  type        = bool
-}
-
 variable "fw_dmz_network_interface_id" {
   type        = list
   description = "Firewall DMZ eni id"
@@ -63,11 +74,6 @@ variable "fw_dmz_network_interface_id" {
 variable "fw_network_interface_id" {
   description = "Firewall network interface id"
   default     = []
-}
-
-variable "instance_tenancy" {
-  description = "A tenancy option for instances launched into the VPC"
-  default     = "default"
 }
 
 variable "map_public_ip_on_launch" {
@@ -114,12 +120,6 @@ variable "public_propagating_vgws" {
 variable "single_nat_gateway" {
   description = "(Optional) A boolean flag to enable/disable use of only a single shared NAT Gateway across all of your private networks. Defaults False."
   default     = false
-}
-
-variable "vpc_cidr" {
-  description = "The CIDR block for the VPC"
-  default     = "10.11.0.0/16"
-  type        = string
 }
 
 variable "vpc_region" {


### PR DESCRIPTION
This branch looks to add VPC flow logs as both a dedicated module into the repository as well as a default to the VPC module as per new Think|Stack best practices. The end result being that VPC flow logs can be built manually and used with that module but by default VPC flow logs will be captured with all clients VPCs.

These changes build out the following
- KMS key
- KMS alias
- IAM policy
- IAM role
- IAM policy attachment to the role
- Cloudwatch group
- VPC flow log

The defaults set within this module set up flow logs on all ENIs (instance NICs) and retain the logs for a set period of days. The cloudwatch logs are encrypted using the KMS key set up within the module.

Since I also modified the VPC module, I cleaned that module up with new coding practices that we've been utilizing on the newer modules.