### PR TITLE
SIEM - Improved the module arguments and variables for optional vpn peering

### DIFF
--- a/modules/thinkstack/siem/README.md
+++ b/modules/thinkstack/siem/README.md
@@ -12,6 +12,7 @@ This module sets up all of the necesarry components for the ThinkStack SIEM secu
         public_key            = "ssh-rsa IAMFAKE2478147921389jhkfdjskafdjklsfajdjslafdjksafljdsajkfdsjklafjdshhr32bn=="
         sg_cidr_blocks        = ["192.168.1.0/24", "10.1.1.0/24", "10.11.0.0/16"]
 
+        enable_vpn_peering    = true
         customer_gw_name      = ["hq_edge"]
         vpn_peer_ip_address   = ["1.1.1.1"]
         vpn_route_cidr_blocks = ["192.168.1.0/24"]
@@ -51,6 +52,7 @@ This module sets up all of the necesarry components for the ThinkStack SIEM secu
     enable_dns_support
     enable_nat_gateway
     enable_vpc_peering
+    enable_vpn_tunnel
     encrypted
     iam_instance_profile
     iam_role_name

--- a/modules/thinkstack/siem/examples/main.tf
+++ b/modules/thinkstack/siem/examples/main.tf
@@ -3,27 +3,28 @@
 ################################################################################################################################
 
 module "siem" {
-  source = "github.com/thinkstack-co/terraform-modules//modules/thinkstack/siem?ref=dev_v0_12_module_upgrade"
+        source                = "github.com/thinkstack-co/terraform-modules//modules/thinkstack/siem?ref=v1.3.3"
 
-  ami            = var.centos_ami[var.aws_region]
-  created_by     = "Zachary Hill"
-  public_key     = "ssh-rsa IAMFAKE2478147921389jhkfdjskafdjklsfajdjslafdjksafljdsajkfdsjklafjdshhr32bn=="
-  sg_cidr_blocks = ["192.168.1.0/24", "10.1.1.0/24", "10.11.0.0/16"]
+        ami                   = var.centos_ami[var.aws_region]
+        created_by            = "Zachary Hill"
+        public_key            = "ssh-rsa IAMFAKE2478147921389jhkfdjskafdjklsfajdjslafdjksafljdsajkfdsjklafjdshhr32bn=="
+        sg_cidr_blocks        = ["192.168.1.0/24", "10.1.1.0/24", "10.11.0.0/16"]
 
-  customer_gw_name      = ["hq_edge"]
-  vpn_peer_ip_address   = ["1.1.1.1"]
-  vpn_route_cidr_blocks = ["192.168.1.0/24"]
+        enable_vpn_peering    = true
+        customer_gw_name      = ["hq_edge"]
+        vpn_peer_ip_address   = ["1.1.1.1"]
+        vpn_route_cidr_blocks = ["192.168.1.0/24"]
 
-  enable_vpc_peering = true
-  peer_vpc_ids       = ["vpc-insertiddhere"]
-  peer_vpc_subnet    = "10.11.0.0/16"
+        enable_vpc_peering    = true
+        peer_vpc_ids          = ["vpc-insertiddhere"]
+        peer_vpc_subnet       = "10.11.0.0/16"
 
-  tags = {
-    created_by  = "Zachary Hill"
-    terraform   = "true"
-    environment = "prod"
-    project     = "SIEM Implementation"
-    team        = "Security Team"
-    used_by     = "ThinkStack"
-  }
-}
+        tags       = {
+            created_by  = "Zachary Hill"
+            terraform   = "true"
+            environment = "prod"
+            project     = "SIEM Implementation"
+            team        = "Security Team"
+            used_by     = "ThinkStack"
+        }
+    }

--- a/modules/thinkstack/siem/main.tf
+++ b/modules/thinkstack/siem/main.tf
@@ -139,12 +139,13 @@ resource "aws_route" "vpc_peer_route" {
 ###########################
 
 resource "aws_vpn_gateway" "vpn_gateway" {
+  count      = var.enable_vpn_peering ? 1 : 0
   vpc_id = aws_vpc.vpc.id
   tags   = merge(var.tags, ({ "Name" = format("%s_vpn_gw", var.name) }))
 }
 
 resource "aws_customer_gateway" "customer_gateway" {
-  count      = var.enable_vpn_tunnel ? length(var.vpn_peer_ip_address) : 0
+  count      = var.enable_vpn_peering ? length(var.vpn_peer_ip_address) : 0
   bgp_asn    = var.bgp_asn
   ip_address = var.vpn_peer_ip_address[count.index]
   type       = var.vpn_type
@@ -152,7 +153,7 @@ resource "aws_customer_gateway" "customer_gateway" {
 }
 
 resource "aws_vpn_connection" "vpn_connection" {
-  count               = var.enable_vpn_tunnel ? length(var.vpn_peer_ip_address) : 0
+  count               = var.enable_vpn_peering ? length(var.vpn_peer_ip_address) : 0
   customer_gateway_id = aws_customer_gateway.customer_gateway[count.index].id
   static_routes_only  = var.static_routes_only
   tags                = merge(var.tags, ({ "Name" = format("%s_vpn_connection", var.name) }))
@@ -161,7 +162,7 @@ resource "aws_vpn_connection" "vpn_connection" {
 }
 
 resource "aws_vpn_connection_route" "vpn_route" {
-  count                  = var.enable_vpn_tunnel ? length(var.vpn_route_cidr_blocks) : 0
+  count                  = var.enable_vpn_peering ? length(var.vpn_route_cidr_blocks) : 0
   destination_cidr_block = var.vpn_route_cidr_blocks[count.index]
   vpn_connection_id      = aws_vpn_connection.vpn_connection[0].id
 }

--- a/modules/thinkstack/siem/variables.tf
+++ b/modules/thinkstack/siem/variables.tf
@@ -63,9 +63,9 @@ variable "enable_vpc_peering" {
   default     = false
 }
 
-variable "enable_vpn_tunnel" {
+variable "enable_vpn_peering" {
   description = "(Required)Boolean which should be set to true if you want to enable and set up a vpn tunnel"
-  default     = true
+  default     = false
 }
 
 variable "encrypted" {


### PR DESCRIPTION
The original module settings were triggered by enable_vpn_tunnel which was not in line with the VPC peering or TGW peering attachment naming. In an effort to simplify and standardize the variable 'enable_vpn_tunnel' was changed to 'enable_vpn_peering'. Additionally, this variable now can enable or disable the VPN gateway itself entirely, whereas previously the VPN gateway was always created even if no tunnels were created.