### PR TITLE
Module - route - removed instance_id as this is now depreciated on the latest version

### DIFF
--- a/modules/aws/route/README.md
+++ b/modules/aws/route/README.md
@@ -2,7 +2,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 0.15.0 |
 
 ## Providers
 
@@ -18,7 +18,6 @@
 | destination\_ipv6\_cidr\_block | (Optional) The destination IPv6 CIDR block. | `string` | `null` | no |
 | egress\_only\_gateway\_id | (Optional) An ID of a VPC Egress Only Internet Gateway. | `string` | `""` | no |
 | gateway\_id | (Optional) An ID of a VPC internet gateway or a virtual private gateway. | `string` | `""` | no |
-| instance\_id | (Optional) An ID of an EC2 instance. | `string` | `""` | no |
 | nat\_gateway\_id | (Optional) An ID of a VPC NAT gateway. | `string` | `""` | no |
 | network\_interface\_id | (Optional) An ID of a network interface. | `list` | `[]` | no |
 | route\_table\_id | (Required) The ID of the routing table. | `list` | n/a | yes |

--- a/modules/aws/route/main.tf
+++ b/modules/aws/route/main.tf
@@ -9,7 +9,6 @@ resource "aws_route" "route" {
   destination_ipv6_cidr_block = var.destination_ipv6_cidr_block
   egress_only_gateway_id      = var.egress_only_gateway_id
   gateway_id                  = var.gateway_id
-  instance_id                 = var.instance_id
   local_gateway_id            = var.local_gateway_id
   nat_gateway_id              = var.nat_gateway_id
   network_interface_id        = var.network_interface_id

--- a/modules/aws/route/variables.tf
+++ b/modules/aws/route/variables.tf
@@ -27,12 +27,6 @@ variable "gateway_id" {
   default     = null
 }
 
-variable "instance_id" {
-  type        = string
-  description = "(Optional) An ID of an EC2 instance."
-  default     = null
-}
-
 variable "local_gateway_id" {
   type        = string
   description = "(Optional) Identifier of a Outpost local gateway."


### PR DESCRIPTION
The latest version of terraform has depreciated instance_id as an argument. This removes that.