### PR TITLE
Module - VPC Flow Log - I changed the cloudwatch log group retention period to 3 months for V…

### DIFF
--- a/modules/aws/flow_logs/variables.tf
+++ b/modules/aws/flow_logs/variables.tf
@@ -56,7 +56,7 @@ variable "cloudwatch_name_prefix" {
 
 variable "cloudwatch_retention_in_days" {
   description = "(Optional) Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire."
-  default     = 365
+  default     = 90
   type        = number
 }
 

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -187,7 +187,7 @@ variable "cloudwatch_name_prefix" {
 
 variable "cloudwatch_retention_in_days" {
   description = "(Optional) Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653, and 0. If you select 0, the events in the log group are always retained and never expire."
-  default     = 365
+  default     = 90
   type        = number
 }
 


### PR DESCRIPTION
…PC Flow logs

This was in order to reduce the cost overhead of packet captures and flow logs for our clients by default.