### PR TITLE
Dev_tgw_connect_attachment_module

### DIFF
--- a/modules/aws/transit_gateway_connect/README.md
+++ b/modules/aws/transit_gateway_connect/README.md
@@ -3,8 +3,8 @@
         source                  = "github.com/thinkstack-co/terraform-modules//modules/aws/transit_gateway_connect"
 
         name                    = "tgw_sdwan_connect"
-        transport_attachment_id = "module.prod_vpc_attachment.id"
-        transit_gateway_id      = "module.transit_gateway.id"
+        transport_attachment_id = module.prod_vpc_attachment.id
+        transit_gateway_id      = module.transit_gateway.id
     }
 
 <!-- BEGIN_TF_DOCS -->

--- a/modules/aws/transit_gateway_connect/README.md
+++ b/modules/aws/transit_gateway_connect/README.md
@@ -1,7 +1,8 @@
 # Usage
-    module "transit_gateway_fw_connect" {
+    module "transit_gateway_sdwan_connect" {
         source                  = "github.com/thinkstack-co/terraform-modules//modules/aws/transit_gateway_connect"
 
+        name                    = "tgw_sdwan_connect"
         transport_attachment_id = "module.prod_vpc_attachment.id"
         transit_gateway_id      = "module.transit_gateway.id"
     }

--- a/modules/aws/transit_gateway_connect/README.md
+++ b/modules/aws/transit_gateway_connect/README.md
@@ -1,0 +1,7 @@
+# Usage
+    module "transit_gateway_fw_connect" {
+        source                  = "github.com/thinkstack-co/terraform-modules//modules/aws/transit_gateway_connect"
+
+        transport_attachment_id = "module.prod_vpc_attachment.id"
+        transit_gateway_id      = "module.transit_gateway.id"
+    }

--- a/modules/aws/transit_gateway_connect/README.md
+++ b/modules/aws/transit_gateway_connect/README.md
@@ -6,3 +6,43 @@
         transport_attachment_id = "module.prod_vpc_attachment.id"
         transit_gateway_id      = "module.transit_gateway.id"
     }
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ec2_transit_gateway_connect.connect_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_connect) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name of the transit gateway | `string` | n/a | yes |
+| <a name="input_protocol"></a> [protocol](#input\_protocol) | (Optional) The tunnel protocol. Valida values: gre. Default is gre. | `string` | `"gre"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Key-value tags for the EC2 Transit Gateway Connect. If configured with a provider default\_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level. | `map` | <pre>{<br>  "environment": "prod",<br>  "project": "core_infrastructure",<br>  "terraform": "true"<br>}</pre> | no |
+| <a name="input_transit_gateway_default_route_table_association"></a> [transit\_gateway\_default\_route\_table\_association](#input\_transit\_gateway\_default\_route\_table\_association) | (Optional) Boolean whether the Connect should be associated with the EC2 Transit Gateway association default route table. This cannot be configured or perform drift detection with Resource Access Manager shared EC2 Transit Gateways. Default value: true. | `bool` | `true` | no |
+| <a name="input_transit_gateway_default_route_table_propagation"></a> [transit\_gateway\_default\_route\_table\_propagation](#input\_transit\_gateway\_default\_route\_table\_propagation) | (Optional) Boolean whether the Connect should propagate routes with the EC2 Transit Gateway propagation default route table. This cannot be configured or perform drift detection with Resource Access Manager shared EC2 Transit Gateways. Default value: true. | `bool` | `true` | no |
+| <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input\_transit\_gateway\_id) | (Required) Identifier of EC2 Transit Gateway. | `string` | n/a | yes |
+| <a name="input_transport_attachment_id"></a> [transport\_attachment\_id](#input\_transport\_attachment\_id) | (Required) The underlaying VPC attachment | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/aws/transit_gateway_connect/main.tf
+++ b/modules/aws/transit_gateway_connect/main.tf
@@ -1,6 +1,6 @@
 resource "aws_ec2_transit_gateway_connect" "connect_attachment" {
   protocol                                        = var.protocol
-  tags                                            = var.tags
+  tags                                            = merge(tomap({Name = var.name}),var.tags)
   transit_gateway_default_route_table_association = var.transit_gateway_default_route_table_association
   transit_gateway_default_route_table_propagation = var.transit_gateway_default_route_table_propagation
   transport_attachment_id                         = var.transport_attachment_id

--- a/modules/aws/transit_gateway_connect/main.tf
+++ b/modules/aws/transit_gateway_connect/main.tf
@@ -1,0 +1,8 @@
+resource "aws_ec2_transit_gateway_connect" "connect_attachment" {
+  protocol                                        = var.protocol
+  tags                                            = var.tags
+  transit_gateway_default_route_table_association = var.transit_gateway_default_route_table_association
+  transit_gateway_default_route_table_propagation = var.transit_gateway_default_route_table_propagation
+  transport_attachment_id                         = var.transport_attachment_id
+  transit_gateway_id                              = var.transit_gateway_id
+}

--- a/modules/aws/transit_gateway_connect/outputs.tf
+++ b/modules/aws/transit_gateway_connect/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+    value = aws_ec2_transit_gateway_connect.connect_attachment.id
+}

--- a/modules/aws/transit_gateway_connect/variables.tf
+++ b/modules/aws/transit_gateway_connect/variables.tf
@@ -1,0 +1,37 @@
+variable "protocol" {
+    type        = string
+    description = "(Optional) The tunnel protocol. Valida values: gre. Default is gre."
+    default     = "gre"
+}
+
+variable "tags" {
+    type        = map
+    description = "(Optional) Key-value tags for the EC2 Transit Gateway Connect. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level."
+    default     = {
+        terraform   = "true"
+        environment = "prod"
+        project     = "core_infrastructure"
+    }
+}
+
+variable "transit_gateway_default_route_table_association" {
+    type        = bool
+    description = "(Optional) Boolean whether the Connect should be associated with the EC2 Transit Gateway association default route table. This cannot be configured or perform drift detection with Resource Access Manager shared EC2 Transit Gateways. Default value: true."
+    default     = true
+}
+
+variable "transit_gateway_default_route_table_propagation" {
+    type        = bool
+    description = "(Optional) Boolean whether the Connect should propagate routes with the EC2 Transit Gateway propagation default route table. This cannot be configured or perform drift detection with Resource Access Manager shared EC2 Transit Gateways. Default value: true."
+    default     = true
+}
+
+variable "transport_attachment_id" {
+    type        = string
+    description =  "(Required) The underlaying VPC attachment"
+}
+
+variable "transit_gateway_id" {
+    type        = string
+    description =  "(Required) Identifier of EC2 Transit Gateway."
+}

--- a/modules/aws/transit_gateway_connect/variables.tf
+++ b/modules/aws/transit_gateway_connect/variables.tf
@@ -1,3 +1,8 @@
+variable "name" {
+  description = "(Required) The name of the transit gateway"
+  type        = string
+}
+
 variable "protocol" {
     type        = string
     description = "(Optional) The tunnel protocol. Valida values: gre. Default is gre."

--- a/modules/aws/transit_gateway_connect_peer/README.md
+++ b/modules/aws/transit_gateway_connect_peer/README.md
@@ -1,0 +1,10 @@
+# Usage
+    module "transit_gateway_fw_connect_peer" {
+        source                        = "github.com/thinkstack-co/terraform-modules//modules/aws/transit_gateway_connect_peer"
+
+        bgp_asn                       = 64513
+        inside_cidr_blocks            = 
+        peer_address                  = 
+        transit_gateway_address       = 
+        transit_gateway_attachment_id = 
+    }

--- a/modules/aws/transit_gateway_connect_peer/README.md
+++ b/modules/aws/transit_gateway_connect_peer/README.md
@@ -1,11 +1,11 @@
 # Usage
-    module "transit_gateway_fw_connect_peer" {
+    module "transit_gateway_sdwan_connect_peer" {
         source                        = "github.com/thinkstack-co/terraform-modules//modules/aws/transit_gateway_connect_peer"
 
         bgp_asn                       = 64513
-        inside_cidr_blocks            = 
+        inside_cidr_blocks            = 169.254.6.0/29
         name                          = "sdwan_peer"
-        peer_address                  = 
-        transit_gateway_address       = 
-        transit_gateway_attachment_id = 
+        peer_address                  = 10.100.1.10
+        transit_gateway_address       = 10.255.1.11
+        transit_gateway_attachment_id = module.transit_gateway_sdwan_connect.id
     }

--- a/modules/aws/transit_gateway_connect_peer/README.md
+++ b/modules/aws/transit_gateway_connect_peer/README.md
@@ -4,6 +4,7 @@
 
         bgp_asn                       = 64513
         inside_cidr_blocks            = 
+        name                          = "sdwan_peer"
         peer_address                  = 
         transit_gateway_address       = 
         transit_gateway_attachment_id = 

--- a/modules/aws/transit_gateway_connect_peer/README.md
+++ b/modules/aws/transit_gateway_connect_peer/README.md
@@ -3,9 +3,49 @@
         source                        = "github.com/thinkstack-co/terraform-modules//modules/aws/transit_gateway_connect_peer"
 
         bgp_asn                       = 64513
-        inside_cidr_blocks            = 169.254.6.0/29
+        inside_cidr_blocks            = "169.254.6.0/29"
         name                          = "sdwan_peer"
-        peer_address                  = 10.100.1.10
-        transit_gateway_address       = 10.255.1.11
+        peer_address                  = "10.100.1.10"
+        transit_gateway_address       = "10.255.1.11"
         transit_gateway_attachment_id = module.transit_gateway_sdwan_connect.id
     }
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ec2_transit_gateway_connect_peer.peer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_connect_peer) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bgp_asn"></a> [bgp\_asn](#input\_bgp\_asn) | (Optional) The BGP ASN number assigned customer device. If not provided, it will use the same BGP ASN as is associated with Transit Gateway. | `number` | `64512` | no |
+| <a name="input_inside_cidr_blocks"></a> [inside\_cidr\_blocks](#input\_inside\_cidr\_blocks) | (Required) The CIDR block that will be used for addressing within the tunnel. It must contain exactly one IPv4 CIDR block and up to one IPv6 CIDR block. The IPv4 CIDR block must be /29 size and must be within 169.254.0.0/16 range, with exception of: 169.254.0.0/29, 169.254.1.0/29, 169.254.2.0/29, 169.254.3.0/29, 169.254.4.0/29, 169.254.5.0/29, 169.254.169.248/29. The IPv6 CIDR block must be /125 size and must be within fd00::/8. The first IP from each CIDR block is assigned for customer gateway, the second and third is for Transit Gateway (An example: from range 169.254.100.0/29, .1 is assigned to customer gateway and .2 and .3 are assigned to Transit Gateway) | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name of the transit gateway | `string` | n/a | yes |
+| <a name="input_peer_address"></a> [peer\_address](#input\_peer\_address) | (Required) The IP addressed assigned to customer device, which will be used as tunnel endpoint. It can be IPv4 or IPv6 address, but must be the same address family as transit\_gateway\_address | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) Key-value tags for the EC2 Transit Gateway Connect. If configured with a provider default\_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level. | `map` | <pre>{<br>  "environment": "prod",<br>  "project": "core_infrastructure",<br>  "terraform": "true"<br>}</pre> | no |
+| <a name="input_transit_gateway_address"></a> [transit\_gateway\_address](#input\_transit\_gateway\_address) | (Required) The IP address assigned to Transit Gateway, which will be used as tunnel endpoint. This address must be from associated Transit Gateway CIDR block. The address must be from the same address family as peer\_address. If not set explicitly, it will be selected from associated Transit Gateway CIDR blocks | `string` | n/a | yes |
+| <a name="input_transit_gateway_attachment_id"></a> [transit\_gateway\_attachment\_id](#input\_transit\_gateway\_attachment\_id) | (Required) The Transit Gateway Connect | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/aws/transit_gateway_connect_peer/main.tf
+++ b/modules/aws/transit_gateway_connect_peer/main.tf
@@ -2,7 +2,7 @@ resource "aws_ec2_transit_gateway_connect_peer" "peer" {
   bgp_asn                       = var.bgp_asn
   inside_cidr_blocks            = var.inside_cidr_blocks
   peer_address                  = var.peer_address
-  tags                          = var.tags
+  tags                          = merge(tomap({Name = var.name}),var.tags)
   transit_gateway_attachment_id = var.transit_gateway_attachment_id
   transit_gateway_address = var.transit_gateway_address
 }

--- a/modules/aws/transit_gateway_connect_peer/main.tf
+++ b/modules/aws/transit_gateway_connect_peer/main.tf
@@ -4,5 +4,5 @@ resource "aws_ec2_transit_gateway_connect_peer" "peer" {
   peer_address                  = var.peer_address
   tags                          = merge(tomap({Name = var.name}),var.tags)
   transit_gateway_attachment_id = var.transit_gateway_attachment_id
-  transit_gateway_address = var.transit_gateway_address
+  transit_gateway_address       = var.transit_gateway_address
 }

--- a/modules/aws/transit_gateway_connect_peer/main.tf
+++ b/modules/aws/transit_gateway_connect_peer/main.tf
@@ -1,0 +1,8 @@
+resource "aws_ec2_transit_gateway_connect_peer" "peer" {
+  bgp_asn                       = var.bgp_asn
+  inside_cidr_blocks            = var.inside_cidr_blocks
+  peer_address                  = var.peer_address
+  tags                          = var.tags
+  transit_gateway_attachment_id = var.transit_gateway_attachment_id
+  transit_gateway_address = var.transit_gateway_address
+}

--- a/modules/aws/transit_gateway_connect_peer/outputs.tf
+++ b/modules/aws/transit_gateway_connect_peer/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+    value = aws_ec2_transit_gateway_connect_peer.peer.id
+}

--- a/modules/aws/transit_gateway_connect_peer/variables.tf
+++ b/modules/aws/transit_gateway_connect_peer/variables.tf
@@ -1,0 +1,35 @@
+variable "bgp_asn" {
+    type        = number
+    description = "(Optional) The BGP ASN number assigned customer device. If not provided, it will use the same BGP ASN as is associated with Transit Gateway."
+    default     = 64512
+}
+
+variable "inside_cidr_blocks" {
+    type        = string
+    description =  "(Required) The CIDR block that will be used for addressing within the tunnel. It must contain exactly one IPv4 CIDR block and up to one IPv6 CIDR block. The IPv4 CIDR block must be /29 size and must be within 169.254.0.0/16 range, with exception of: 169.254.0.0/29, 169.254.1.0/29, 169.254.2.0/29, 169.254.3.0/29, 169.254.4.0/29, 169.254.5.0/29, 169.254.169.248/29. The IPv6 CIDR block must be /125 size and must be within fd00::/8. The first IP from each CIDR block is assigned for customer gateway, the second and third is for Transit Gateway (An example: from range 169.254.100.0/29, .1 is assigned to customer gateway and .2 and .3 are assigned to Transit Gateway)"
+}
+
+variable "peer_address" {
+    type        = string
+    description =  "(Required) The IP addressed assigned to customer device, which will be used as tunnel endpoint. It can be IPv4 or IPv6 address, but must be the same address family as transit_gateway_address"
+}
+
+variable "tags" {
+    type        = map
+    description = "(Optional) Key-value tags for the EC2 Transit Gateway Connect. If configured with a provider default_tags configuration block present, tags with matching keys will overwrite those defined at the provider-level."
+    default     = {
+        terraform   = "true"
+        environment = "prod"
+        project     = "core_infrastructure"
+    }
+}
+
+variable "transit_gateway_address" {
+    type        = string
+    description = "(Required) The IP address assigned to Transit Gateway, which will be used as tunnel endpoint. This address must be from associated Transit Gateway CIDR block. The address must be from the same address family as peer_address. If not set explicitly, it will be selected from associated Transit Gateway CIDR blocks"
+}
+
+variable "transit_gateway_attachment_id" {
+    type        = string
+    description = "(Required) The Transit Gateway Connect"
+}

--- a/modules/aws/transit_gateway_connect_peer/variables.tf
+++ b/modules/aws/transit_gateway_connect_peer/variables.tf
@@ -9,6 +9,11 @@ variable "inside_cidr_blocks" {
     description =  "(Required) The CIDR block that will be used for addressing within the tunnel. It must contain exactly one IPv4 CIDR block and up to one IPv6 CIDR block. The IPv4 CIDR block must be /29 size and must be within 169.254.0.0/16 range, with exception of: 169.254.0.0/29, 169.254.1.0/29, 169.254.2.0/29, 169.254.3.0/29, 169.254.4.0/29, 169.254.5.0/29, 169.254.169.248/29. The IPv6 CIDR block must be /125 size and must be within fd00::/8. The first IP from each CIDR block is assigned for customer gateway, the second and third is for Transit Gateway (An example: from range 169.254.100.0/29, .1 is assigned to customer gateway and .2 and .3 are assigned to Transit Gateway)"
 }
 
+variable "name" {
+  description = "(Required) The name of the transit gateway"
+  type        = string
+}
+
 variable "peer_address" {
     type        = string
     description =  "(Required) The IP addressed assigned to customer device, which will be used as tunnel endpoint. It can be IPv4 or IPv6 address, but must be the same address family as transit_gateway_address"

--- a/modules/aws/transit_gateway_connect_peer/variables.tf
+++ b/modules/aws/transit_gateway_connect_peer/variables.tf
@@ -5,7 +5,7 @@ variable "bgp_asn" {
 }
 
 variable "inside_cidr_blocks" {
-    type        = string
+    type        = list(string)
     description =  "(Required) The CIDR block that will be used for addressing within the tunnel. It must contain exactly one IPv4 CIDR block and up to one IPv6 CIDR block. The IPv4 CIDR block must be /29 size and must be within 169.254.0.0/16 range, with exception of: 169.254.0.0/29, 169.254.1.0/29, 169.254.2.0/29, 169.254.3.0/29, 169.254.4.0/29, 169.254.5.0/29, 169.254.169.248/29. The IPv6 CIDR block must be /125 size and must be within fd00::/8. The first IP from each CIDR block is assigned for customer gateway, the second and third is for Transit Gateway (An example: from range 169.254.100.0/29, .1 is assigned to customer gateway and .2 and .3 are assigned to Transit Gateway)"
 }
 


### PR DESCRIPTION
Added transit_gateway_connect and transit_gateway_connect_peer modules allowing for a TGW connect attachment. Used in SDWAN configurations for BGP peering to the TGW and failover.